### PR TITLE
feat: 상품 상세 페이지 기본 레이아웃 구현

### DIFF
--- a/src/app/(consumer)/products/[productId]/page.tsx
+++ b/src/app/(consumer)/products/[productId]/page.tsx
@@ -108,21 +108,31 @@ export default async function ProductDetailPage({
 
         <section className="mx-auto max-w-450 px-6 pb-16">
           <div className="border-b border-gray-200">
-            <nav className="flex gap-10">
+            <nav
+              className="flex gap-10"
+              role="tablist"
+              aria-label="상품 상세 정보"
+            >
               <button
                 type="button"
+                role="tab"
+                aria-selected="true"
                 className="border-primary-500 text-primary-500 border-b-2 px-2 py-4 text-sm font-semibold"
               >
                 상세정보
               </button>
               <button
                 type="button"
+                role="tab"
+                aria-selected="false"
                 className="px-2 py-4 text-sm font-semibold text-gray-600"
               >
                 리뷰
               </button>
               <button
                 type="button"
+                role="tab"
+                aria-selected="false"
                 className="px-2 py-4 text-sm font-semibold text-gray-600"
               >
                 매장 정보

--- a/src/app/(consumer)/products/[productId]/page.tsx
+++ b/src/app/(consumer)/products/[productId]/page.tsx
@@ -1,0 +1,145 @@
+import { notFound } from 'next/navigation';
+
+import { Footer, Header } from '@/components/common';
+import { ProductReservationPanel } from '@/components/consumer/ProductReservationPanel';
+import { mockProductDetailsMap } from '@/mocks/products';
+
+interface ProductDetailPageProps {
+  params: Promise<{ productId: string }>;
+}
+
+const thumbnailPlaceholders = [
+  'thumbnail-1',
+  'thumbnail-2',
+  'thumbnail-3',
+  'thumbnail-4',
+  'thumbnail-5',
+];
+
+export default async function ProductDetailPage({
+  params,
+}: ProductDetailPageProps) {
+  const { productId } = await params;
+  const product = mockProductDetailsMap[productId];
+
+  if (!product) {
+    notFound();
+  }
+
+  return (
+    <div className="bg-white">
+      <Header user={null} logoHref="/" />
+
+      <main className="min-h-screen bg-white">
+        <section className="mx-auto grid max-w-450 gap-8 px-6 py-10 lg:grid-cols-[minmax(0,1fr)_400px] xl:grid-cols-[minmax(0,1fr)_460px]">
+          <div className="grid gap-8 xl:grid-cols-[560px_minmax(0,1fr)]">
+            <div>
+              <div className="flex aspect-square items-center justify-center rounded-lg bg-gray-100 text-sm font-medium text-gray-500">
+                이미지 영역
+              </div>
+
+              <div className="mt-4 grid grid-cols-5 gap-3">
+                {thumbnailPlaceholders.map((thumbnail, index) => (
+                  <button
+                    key={thumbnail}
+                    type="button"
+                    className="aspect-square rounded-md border border-gray-200 bg-gray-50 text-xs text-gray-400"
+                  >
+                    {index + 1}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <span className="bg-primary-50 text-primary-500 mb-4 inline-flex rounded-sm px-3 py-1 text-xs font-semibold">
+                픽마 추천
+              </span>
+
+              <p className="mb-2 text-base font-semibold text-gray-700">
+                {product.store.name}
+              </p>
+              <h1 className="text-3xl leading-tight font-bold text-gray-900">
+                {product.name}
+              </h1>
+
+              <p className="mt-5 text-sm leading-6 text-gray-700">
+                {product.description ?? '상품 상세 설명 영역'}
+              </p>
+
+              <div className="mt-6 flex items-end gap-3">
+                <strong className="text-primary-500 text-3xl font-bold">
+                  {product.discountPrice.toLocaleString()}원
+                </strong>
+                <span className="text-sm text-gray-400 line-through">
+                  {product.originalPrice.toLocaleString()}원
+                </span>
+                <span className="text-primary-500 text-sm font-bold">
+                  {product.discountRate}%
+                </span>
+              </div>
+
+              <dl className="mt-8 space-y-4 border-t border-gray-200 pt-6 text-sm">
+                <div className="grid grid-cols-[96px_minmax(0,1fr)] gap-4">
+                  <dt className="font-semibold text-gray-500">판매처</dt>
+                  <dd className="text-gray-900">{product.store.name}</dd>
+                </div>
+                <div className="grid grid-cols-[96px_minmax(0,1fr)] gap-4">
+                  <dt className="font-semibold text-gray-500">픽업장소</dt>
+                  <dd className="text-gray-900">
+                    {product.store.address}
+                    {product.store.addressDetail
+                      ? ` ${product.store.addressDetail}`
+                      : ''}
+                  </dd>
+                </div>
+                <div className="grid grid-cols-[96px_minmax(0,1fr)] gap-4">
+                  <dt className="font-semibold text-gray-500">남은 수량</dt>
+                  <dd className="text-gray-900">{product.availableStock}개</dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+
+          <aside className="lg:sticky lg:top-24 lg:self-start">
+            <ProductReservationPanel price={product.discountPrice} />
+          </aside>
+        </section>
+
+        <section className="mx-auto max-w-450 px-6 pb-16">
+          <div className="border-b border-gray-200">
+            <nav className="flex gap-10">
+              <button
+                type="button"
+                className="border-primary-500 text-primary-500 border-b-2 px-2 py-4 text-sm font-semibold"
+              >
+                상세정보
+              </button>
+              <button
+                type="button"
+                className="px-2 py-4 text-sm font-semibold text-gray-600"
+              >
+                리뷰
+              </button>
+              <button
+                type="button"
+                className="px-2 py-4 text-sm font-semibold text-gray-600"
+              >
+                매장 정보
+              </button>
+            </nav>
+          </div>
+
+          <div className="py-8">
+            <h2 className="mb-4 text-lg font-bold text-gray-900">상품 안내</h2>
+            <p className="text-sm leading-6 text-gray-700">
+              상품 상세 설명 영역
+            </p>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/(consumer)/products/[productId]/page.tsx
+++ b/src/app/(consumer)/products/[productId]/page.tsx
@@ -43,6 +43,7 @@ export default async function ProductDetailPage({
                   <button
                     key={thumbnail}
                     type="button"
+                    aria-label={`${index + 1}번째 상품 이미지 보기`}
                     className="aspect-square rounded-md border border-gray-200 bg-gray-50 text-xs text-gray-400"
                   >
                     {index + 1}

--- a/src/components/consumer/ProductReservationPanel.tsx
+++ b/src/components/consumer/ProductReservationPanel.tsx
@@ -1,0 +1,38 @@
+import { Button } from '@/components/common';
+
+interface ProductReservationPanelProps {
+  price: number;
+}
+
+export function ProductReservationPanel({
+  price,
+}: ProductReservationPanelProps) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-6">
+      <h2 className="mb-4 text-lg font-bold text-gray-900">
+        픽업 날짜 및 시간 선택
+      </h2>
+
+      <div className="mb-6 rounded-md border border-gray-200 p-4 text-sm text-gray-600">
+        시간 선택 영역
+      </div>
+
+      <div className="mb-6">
+        <p className="mb-3 text-sm font-semibold text-gray-900">수량 선택</p>
+        <div className="flex w-fit items-center rounded-md border border-gray-200">
+          <button type="button" className="px-4 py-2 text-gray-600">
+            -
+          </button>
+          <span className="px-4 py-2 text-sm font-medium">1</span>
+          <button type="button" className="px-4 py-2 text-gray-600">
+            +
+          </button>
+        </div>
+      </div>
+
+      <Button className="w-full py-3 text-sm font-bold">
+        {price.toLocaleString()}원 담기
+      </Button>
+    </div>
+  );
+}

--- a/src/components/consumer/ProductReservationPanel.tsx
+++ b/src/components/consumer/ProductReservationPanel.tsx
@@ -20,11 +20,19 @@ export function ProductReservationPanel({
       <div className="mb-6">
         <p className="mb-3 text-sm font-semibold text-gray-900">수량 선택</p>
         <div className="flex w-fit items-center rounded-md border border-gray-200">
-          <button type="button" className="px-4 py-2 text-gray-600">
+          <button
+            type="button"
+            aria-label="수량 감소"
+            className="px-4 py-2 text-gray-600"
+          >
             -
           </button>
           <span className="px-4 py-2 text-sm font-medium">1</span>
-          <button type="button" className="px-4 py-2 text-gray-600">
+          <button
+            type="button"
+            aria-label="수량 증가"
+            className="px-4 py-2 text-gray-600"
+          >
             +
           </button>
         </div>


### PR DESCRIPTION
## 📌 작업 내용

- 소비자 상품 상세 페이지의 기본 라우트와 레이아웃을 구현했습니다.
- `/products/[productId]` 경로에서 mock 상품 상세 데이터를 조회하고, 존재하지 않는 상품은 `notFound` 처리하도록 구성했습니다.
- 상세 페이지 상단의 이미지 영역, 상품 정보 영역, 예약 패널 영역과 하단 탭/상세정보 영역의 기본 구조를 잡았습니다.

> 현재 이 PR은 메인 페이지 PR의 상품 카드 이동 경로(`/products/[productId]`)와 이어지는 작업입니다.  
> 메인 페이지 PR이 먼저 merge된 뒤 이 PR을 merge하는 흐름으로 진행하겠습니다.

## 🔧 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📂 주요 변경 파일

- `src/app/(consumer)/products/[productId]/page.tsx`
- `src/components/consumer/ProductReservationPanel.tsx`

## 🧪 테스트 방법

- `/products/product_1` 접속 → 상품 상세 페이지 기본 레이아웃 노출 확인
- `/products/product_2` 접속 → 다른 mock 상품 데이터 노출 확인
- 존재하지 않는 상품 ID로 접속 → `notFound` 처리 확인
- `npm run lint`
- `npx tsc --noEmit`

## 📸 스크린샷 (선택)

- UI 확인용 스크린샷 첨부 예정

## 🔗 관련 이슈

- close #33 
