### PR TITLE
feat: 상품 상세 정보 영역 구현

### DIFF
--- a/src/app/(consumer)/products/[productId]/page.tsx
+++ b/src/app/(consumer)/products/[productId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 
 import { Footer, Header } from '@/components/common';
+import { ProductDetailInfo } from '@/components/consumer/ProductDetailInfo';
 import { ProductImageGallery } from '@/components/consumer/ProductImageGallery';
 import { ProductReservationPanel } from '@/components/consumer/ProductReservationPanel';
 import { mockProductDetailsMap } from '@/mocks/products';
@@ -30,54 +31,8 @@ export default async function ProductDetailPage({
               productName={product.name}
               imageUrl={product.image}
             />
-            <div>
-              <span className="bg-primary-50 text-primary-500 mb-4 inline-flex rounded-sm px-3 py-1 text-xs font-semibold">
-                픽마 추천
-              </span>
 
-              <p className="mb-2 text-base font-semibold text-gray-700">
-                {product.store.name}
-              </p>
-              <h1 className="text-3xl leading-tight font-bold text-gray-900">
-                {product.name}
-              </h1>
-
-              <p className="mt-5 text-sm leading-6 text-gray-700">
-                {product.description ?? '상품 상세 설명 영역'}
-              </p>
-
-              <div className="mt-6 flex items-end gap-3">
-                <strong className="text-primary-500 text-3xl font-bold">
-                  {product.discountPrice.toLocaleString()}원
-                </strong>
-                <span className="text-sm text-gray-400 line-through">
-                  {product.originalPrice.toLocaleString()}원
-                </span>
-                <span className="text-primary-500 text-sm font-bold">
-                  {product.discountRate}%
-                </span>
-              </div>
-
-              <dl className="mt-8 space-y-4 border-t border-gray-200 pt-6 text-sm">
-                <div className="grid grid-cols-[96px_minmax(0,1fr)] gap-4">
-                  <dt className="font-semibold text-gray-500">판매처</dt>
-                  <dd className="text-gray-900">{product.store.name}</dd>
-                </div>
-                <div className="grid grid-cols-[96px_minmax(0,1fr)] gap-4">
-                  <dt className="font-semibold text-gray-500">픽업장소</dt>
-                  <dd className="text-gray-900">
-                    {product.store.address}
-                    {product.store.addressDetail
-                      ? ` ${product.store.addressDetail}`
-                      : ''}
-                  </dd>
-                </div>
-                <div className="grid grid-cols-[96px_minmax(0,1fr)] gap-4">
-                  <dt className="font-semibold text-gray-500">남은 수량</dt>
-                  <dd className="text-gray-900">{product.availableStock}개</dd>
-                </div>
-              </dl>
-            </div>
+            <ProductDetailInfo product={product} />
           </div>
 
           <aside className="lg:sticky lg:top-24 lg:self-start">

--- a/src/components/consumer/ProductCard.tsx
+++ b/src/components/consumer/ProductCard.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import type { ProductListItemResponse } from '@/contracts/product';
+import { formatPickupTime } from '@/lib/formatPickupTime';
 import { isProductUnavailable } from '@/lib/product';
 import { useNow } from '@/hooks/useNow';
 import { Badge, Button } from '@/components/common';
@@ -37,14 +38,6 @@ function formatRemainingTime(endAt: string, now: number) {
 
 function isProductUnavailableBeforeHydration(product: ProductListItemResponse) {
   return product.isSoldOut || product.isExpired || product.availableStock <= 0;
-}
-
-function formatPickupTime(value: string) {
-  return new Intl.DateTimeFormat('ko-KR', {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  }).format(new Date(value));
 }
 
 export function ProductCard({ product }: ProductCardProps) {

--- a/src/components/consumer/ProductDetailInfo.tsx
+++ b/src/components/consumer/ProductDetailInfo.tsx
@@ -9,10 +9,6 @@ interface ProductDetailInfoProps {
 }
 
 function getProductStatus(product: ProductDetailResponse) {
-  if (product.isSoldOut || product.displayStatus === 'soldOut') {
-    return { label: '품절', color: 'gray' as const };
-  }
-
   if (
     product.isExpired ||
     product.displayStatus === 'expired' ||
@@ -20,6 +16,10 @@ function getProductStatus(product: ProductDetailResponse) {
     product.status === 'closed'
   ) {
     return { label: '마감', color: 'dark' as const };
+  }
+
+  if (product.isSoldOut || product.displayStatus === 'soldOut') {
+    return { label: '품절', color: 'gray' as const };
   }
 
   if (product.availableStock <= 0) {
@@ -70,7 +70,7 @@ export function ProductDetailInfo({ product }: ProductDetailInfoProps) {
       </div>
 
       <Badge className="mt-3" color="primary" rounded="md">
-        픽마가
+        픽마 할인가
       </Badge>
 
       <p className="mt-3 text-sm text-gray-500">

--- a/src/components/consumer/ProductDetailInfo.tsx
+++ b/src/components/consumer/ProductDetailInfo.tsx
@@ -36,9 +36,6 @@ export function ProductDetailInfo({ product }: ProductDetailInfoProps) {
   return (
     <section aria-labelledby="product-detail-title">
       <div className="mb-4 flex flex-wrap items-center gap-2">
-        <Badge color="primary" rounded="md">
-          픽마 추천
-        </Badge>
         <Badge color={status.color} rounded="md">
           {status.label}
         </Badge>

--- a/src/components/consumer/ProductDetailInfo.tsx
+++ b/src/components/consumer/ProductDetailInfo.tsx
@@ -52,7 +52,7 @@ export function ProductDetailInfo({ product }: ProductDetailInfoProps) {
       </h1>
 
       {product.description && (
-        <p className="mt-5 text-sm leading-6 text-gray-700">
+        <p className="mt-5 text-lg leading-6 text-gray-700">
           {product.description}
         </p>
       )}
@@ -89,9 +89,7 @@ export function ProductDetailInfo({ product }: ProductDetailInfoProps) {
           {product.store.address}
           {product.store.addressDetail ? ` ${product.store.addressDetail}` : ''}
         </ProductInfoRow>
-        <ProductInfoRow label="남은 수량">
-          {availableStock}개
-        </ProductInfoRow>
+        <ProductInfoRow label="남은 수량">{availableStock}개</ProductInfoRow>
       </dl>
     </section>
   );

--- a/src/components/consumer/ProductDetailInfo.tsx
+++ b/src/components/consumer/ProductDetailInfo.tsx
@@ -44,12 +44,12 @@ export function ProductDetailInfo({ product }: ProductDetailInfoProps) {
         </Badge>
       </div>
 
-      <p className="mb-2 text-base font-semibold text-gray-700">
+      <p className="mb-2 text-2xl font-semibold text-gray-700">
         {product.store.name}
       </p>
       <h1
         id="product-detail-title"
-        className="text-3xl leading-tight font-bold text-gray-900"
+        className="text-4xl leading-tight font-bold text-gray-900"
       >
         {product.name}
       </h1>
@@ -61,13 +61,13 @@ export function ProductDetailInfo({ product }: ProductDetailInfoProps) {
       )}
 
       <div className="mt-6 flex flex-wrap items-end gap-x-3 gap-y-1">
-        <strong className="text-primary-500 text-3xl font-bold">
+        <strong className="text-primary-500 text-4xl font-bold">
           {product.discountPrice.toLocaleString()}원
         </strong>
-        <span className="text-sm text-gray-400 line-through">
+        <span className="text-lg text-gray-400 line-through">
           {product.originalPrice.toLocaleString()}원
         </span>
-        <span className="text-primary-500 text-sm font-bold">
+        <span className="text-primary-500 text-lg font-bold">
           {product.discountRate}%
         </span>
       </div>
@@ -76,11 +76,11 @@ export function ProductDetailInfo({ product }: ProductDetailInfoProps) {
         픽마가
       </Badge>
 
-      <p className="mt-3 text-xs text-gray-500">
+      <p className="mt-3 text-sm text-gray-500">
         픽업 상품은 지정한 시간에 매장에서 수령해 주세요.
       </p>
 
-      <dl className="mt-8 space-y-5 border-t border-gray-200 pt-6 text-sm">
+      <dl className="mt-8 space-y-5 border-t border-gray-200 pt-6 text-lg">
         <ProductInfoRow label="판매처">{product.store.name}</ProductInfoRow>
         <ProductInfoRow label="픽업 가능">
           <span className="block">

--- a/src/components/consumer/ProductDetailInfo.tsx
+++ b/src/components/consumer/ProductDetailInfo.tsx
@@ -1,0 +1,115 @@
+import type { ReactNode } from 'react';
+
+import type { ProductDetailResponse } from '@/contracts/product';
+import { formatPickupTime } from '@/lib/formatPickupTime';
+import { Badge } from '@/components/common';
+
+interface ProductDetailInfoProps {
+  product: ProductDetailResponse;
+}
+
+function getProductStatus(product: ProductDetailResponse) {
+  if (product.isSoldOut || product.displayStatus === 'soldOut') {
+    return { label: '품절', color: 'gray' as const };
+  }
+
+  if (
+    product.isExpired ||
+    product.displayStatus === 'expired' ||
+    product.displayStatus === 'closed' ||
+    product.status === 'closed'
+  ) {
+    return { label: '마감', color: 'dark' as const };
+  }
+
+  if (product.availableStock <= 0) {
+    return { label: '재고 없음', color: 'gray' as const };
+  }
+
+  return { label: '예약 가능', color: 'primary' as const };
+}
+
+export function ProductDetailInfo({ product }: ProductDetailInfoProps) {
+  const status = getProductStatus(product);
+  const availableStock = Math.max(0, product.availableStock);
+
+  return (
+    <section aria-labelledby="product-detail-title">
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <Badge color="primary" rounded="md">
+          픽마 추천
+        </Badge>
+        <Badge color={status.color} rounded="md">
+          {status.label}
+        </Badge>
+      </div>
+
+      <p className="mb-2 text-base font-semibold text-gray-700">
+        {product.store.name}
+      </p>
+      <h1
+        id="product-detail-title"
+        className="text-3xl leading-tight font-bold text-gray-900"
+      >
+        {product.name}
+      </h1>
+
+      {product.description && (
+        <p className="mt-5 text-sm leading-6 text-gray-700">
+          {product.description}
+        </p>
+      )}
+
+      <div className="mt-6 flex flex-wrap items-end gap-x-3 gap-y-1">
+        <strong className="text-primary-500 text-3xl font-bold">
+          {product.discountPrice.toLocaleString()}원
+        </strong>
+        <span className="text-sm text-gray-400 line-through">
+          {product.originalPrice.toLocaleString()}원
+        </span>
+        <span className="text-primary-500 text-sm font-bold">
+          {product.discountRate}%
+        </span>
+      </div>
+
+      <Badge className="mt-3" color="primary" rounded="md">
+        픽마가
+      </Badge>
+
+      <p className="mt-3 text-xs text-gray-500">
+        픽업 상품은 지정한 시간에 매장에서 수령해 주세요.
+      </p>
+
+      <dl className="mt-8 space-y-5 border-t border-gray-200 pt-6 text-sm">
+        <ProductInfoRow label="판매처">{product.store.name}</ProductInfoRow>
+        <ProductInfoRow label="픽업 가능">
+          <span className="block">
+            {formatPickupTime(product.pickupStartTime)} ~{' '}
+            {formatPickupTime(product.pickupEndTime)}
+          </span>
+        </ProductInfoRow>
+        <ProductInfoRow label="픽업장소">
+          {product.store.address}
+          {product.store.addressDetail ? ` ${product.store.addressDetail}` : ''}
+        </ProductInfoRow>
+        <ProductInfoRow label="남은 수량">
+          {availableStock}개
+        </ProductInfoRow>
+      </dl>
+    </section>
+  );
+}
+
+interface ProductInfoRowProps {
+  label: string;
+  children: ReactNode;
+}
+
+function ProductInfoRow({ label, children }: ProductInfoRowProps) {
+  return (
+    <div className="grid grid-cols-[96px_minmax(0,1fr)] gap-4">
+      <dt className="font-semibold text-gray-500">{label}</dt>
+      <dd className="text-gray-900">{children}</dd>
+    </div>
+  );
+}

--- a/src/lib/formatPickupTime.ts
+++ b/src/lib/formatPickupTime.ts
@@ -19,5 +19,6 @@ export function formatPickupTime(value: string) {
     hour: '2-digit',
     minute: '2-digit',
     hour12: false,
+    timeZone: 'Asia/Seoul',
   }).format(date);
 }

--- a/src/lib/formatPickupTime.ts
+++ b/src/lib/formatPickupTime.ts
@@ -1,8 +1,12 @@
-export function formatPickupTime(value: string) {
-  const timeMatch = value.match(/^(\d{2}):(\d{2})(?::\d{2})?$/);
+const TIME_ONLY_PATTERN = /^(\d{2}):(\d{2})(?::\d{2})?$/;
 
-  if (timeMatch) {
-    return `${timeMatch[1]}:${timeMatch[2]}`;
+export function formatPickupTime(value: string) {
+  const timeOnlyMatch = value.match(TIME_ONLY_PATTERN);
+
+  if (timeOnlyMatch) {
+    const [, hours, minutes] = timeOnlyMatch;
+
+    return `${hours}:${minutes}`;
   }
 
   const date = new Date(value);

--- a/src/lib/formatPickupTime.ts
+++ b/src/lib/formatPickupTime.ts
@@ -1,0 +1,19 @@
+export function formatPickupTime(value: string) {
+  const timeMatch = value.match(/^(\d{2}):(\d{2})(?::\d{2})?$/);
+
+  if (timeMatch) {
+    return `${timeMatch[1]}:${timeMatch[2]}`;
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat('ko-KR', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(date);
+}


### PR DESCRIPTION
## 📌 작업 내용

- 상품 상세 페이지의 상품 정보 영역을 mock 데이터 기반으로 구현했습니다.
- 기존 상세 페이지 레이아웃의 더미 상품 정보 영역을 `ProductDetailInfo` 컴포넌트로 분리했습니다.
- 상품명, 매장명, 가격, 할인율, 픽업 가능 시간, 남은 수량, 픽업 장소, 상품 상태를 표시하도록 구성했습니다.

## 🔧 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 📂 주요 변경 파일

- `src/app/(consumer)/products/[productId]/page.tsx`
- `src/components/consumer/ProductDetailInfo.tsx`
- `src/mocks/products.ts`

## 🧪 테스트 방법

- `/products/product_1` 접속 → 상품 상세 정보 영역 노출 확인
- `/products/product_3` 등 다른 mock 상품 접속 → 상세 정보 노출 확인
- 존재하지 않는 상품 ID 접속 → `notFound` 처리 확인
- `npm run lint`
- `npx tsc --noEmit`

## 📸 스크린샷 (선택)

- UI 확인용 스크린샷 첨부 예정

## 🔗 관련 이슈

- close #39
