### PR TITLE
사용자 정보 수정 API 및 Role 기반 인증 헬퍼 구현

### DIFF
--- a/docs/api_spec.md
+++ b/docs/api_spec.md
@@ -197,6 +197,21 @@ DB source:
 - `users`
 - 필요 시 `stores`를 join해 seller 승인 상태를 함께 조회
 
+#### `PATCH /api/users/me`
+
+Request:
+
+```ts
+export interface UpdateMeRequest {
+  name?: string;
+}
+```
+
+Response: `UserResponse`
+
+- 수정할 필드가 하나 이상 있어야 한다.
+- `active` 상태 사용자만 허용한다.
+
 ---
 
 ## 3. Products
@@ -611,25 +626,26 @@ RPC에서 raise하는 예외는 아래 정책으로 API error code로 변환한�
 
 `create_order`의 validation 예외는 Zod 스키마 검증이 선행되므로 정상 흐름에서는 도달하지 않아야 한다.
 
-| Code                         | HTTP | 메시지                              |
-| ---------------------------- | ---- | ----------------------------------- |
-| `UNAUTHORIZED`               | 401  | 로그인이 필요합니다.                |
-| `FORBIDDEN`                  | 403  | 접근 권한이 없습니다.               |
-| `VALIDATION_ERROR`           | 400  | 요청 값이 올바르지 않습니다.        |
-| `NOT_FOUND`                  | 404  | 요청한 리소스를 찾을 수 없습니다.   |
-| `PRODUCT_NOT_FOUND`          | 404  | 상품을 찾을 수 없습니다.            |
-| `ORDER_NOT_FOUND`            | 404  | 주문을 찾을 수 없습니다.            |
-| `STORE_NOT_FOUND`            | 404  | 가게를 찾을 수 없습니다.            |
-| `STORE_NOT_APPROVED`         | 403  | 승인된 가게만 사용할 수 있습니다.   |
-| `STORE_ALREADY_EXISTS`       | 409  | 이미 등록된 가게가 있습니다.        |
-| `OUT_OF_STOCK`               | 409  | 재고가 부족합니다.                  |
-| `PRODUCT_EXPIRED`            | 409  | 판매가 마감된 상품입니다.           |
-| `PRODUCT_NOT_AVAILABLE`      | 409  | 구매할 수 없는 상품입니다.          |
-| `ORDER_EXPIRED`              | 409  | 결제 가능 시간이 만료되었습니다.    |
-| `DUPLICATE_PRODUCT_IN_ORDER` | 400  | 주문 항목에 중복된 상품이 있습니다. |
-| `PAYMENT_AMOUNT_MISMATCH`    | 400  | 결제 금액이 일치하지 않습니다.      |
-| `PAYMENT_CONFIRM_FAILED`     | 502  | 결제 승인에 실패했습니다.           |
-| `ORDER_NUMBER_EXHAUSTED`     | 503  | 주문번호가 모두 소진되었습니다.     |
-| `PICKUP_NUMBER_EXHAUSTED`    | 409  | 픽업 번호가 모두 소진되었습니다.    |
-| `NOT_IMPLEMENTED`            | 501  | 아직 구현되지 않은 API입니다.       |
-| `INTERNAL_SERVER_ERROR`      | 500  | 서버 오류가 발생했습니다.           |
+| Code                         | HTTP | 메시지                                         |
+| ---------------------------- | ---- | ---------------------------------------------- |
+| `UNAUTHORIZED`               | 401  | 로그인이 필요합니다.                           |
+| `FORBIDDEN`                  | 403  | 접근 권한이 없습니다.                          |
+| `VALIDATION_ERROR`           | 400  | 요청 값이 올바르지 않습니다.                   |
+| `NOT_FOUND`                  | 404  | 요청한 리소스를 찾을 수 없습니다.              |
+| `PRODUCT_NOT_FOUND`          | 404  | 상품을 찾을 수 없습니다.                       |
+| `ORDER_NOT_FOUND`            | 404  | 주문을 찾을 수 없습니다.                       |
+| `STORE_NOT_FOUND`            | 404  | 가게를 찾을 수 없습니다.                       |
+| `STORE_NOT_APPROVED`         | 403  | 승인된 가게만 사용할 수 있습니다.              |
+| `STORE_ALREADY_EXISTS`       | 409  | 이미 등록된 가게가 있습니다.                   |
+| `AUTH_IDENTITY_CONFLICT`     | 409  | 이미 다른 로그인 방식으로 가입된 이메일입니다. |
+| `OUT_OF_STOCK`               | 409  | 재고가 부족합니다.                             |
+| `PRODUCT_EXPIRED`            | 409  | 판매가 마감된 상품입니다.                      |
+| `PRODUCT_NOT_AVAILABLE`      | 409  | 구매할 수 없는 상품입니다.                     |
+| `ORDER_EXPIRED`              | 409  | 결제 가능 시간이 만료되었습니다.               |
+| `DUPLICATE_PRODUCT_IN_ORDER` | 400  | 주문 항목에 중복된 상품이 있습니다.            |
+| `PAYMENT_AMOUNT_MISMATCH`    | 400  | 결제 금액이 일치하지 않습니다.                 |
+| `PAYMENT_CONFIRM_FAILED`     | 502  | 결제 승인에 실패했습니다.                      |
+| `ORDER_NUMBER_EXHAUSTED`     | 503  | 주문번호가 모두 소진되었습니다.                |
+| `PICKUP_NUMBER_EXHAUSTED`    | 409  | 픽업 번호가 모두 소진되었습니다.               |
+| `NOT_IMPLEMENTED`            | 501  | 아직 구현되지 않은 API입니다.                  |
+| `INTERNAL_SERVER_ERROR`      | 500  | 서버 오류가 발생했습니다.                      |

--- a/docs/domain.md
+++ b/docs/domain.md
@@ -85,8 +85,8 @@ export interface Store {
   addressDetail?: string;
   region: string;
   image?: string;
-  openTime?: Date;
-  closeTime?: Date;
+  openTime?: string;
+  closeTime?: string;
   status: StoreStatus;
   rejectReason?: string;
   createdAt: Date;

--- a/docs/system_architecture.md
+++ b/docs/system_architecture.md
@@ -121,7 +121,7 @@ export const config = {
 src/lib/supabase/client.ts   # 브라우저용 Supabase client
 src/lib/supabase/server.ts   # Route Handler / Server Component용 Supabase client
 src/lib/supabase/proxy.ts    # proxy 세션 refresh용 helper
-src/lib/supabase/service.ts  # service_role 서버 전용 client (RPC 호출용)
+src/lib/supabase/service.ts  # service_role 서버 전용 client (RLS bypass, 서버 전용)
 ```
 
 - Supabase browser/server/proxy client는 `@supabase/ssr` 기준으로 구현한다.

--- a/src/api/users/userApi.ts
+++ b/src/api/users/userApi.ts
@@ -1,5 +1,5 @@
 import type { User } from '@/types/user';
-import type { UserResponse } from '@/contracts/user';
+import type { UpdateMeRequest, UserResponse } from '@/contracts/user';
 
 import { apiClient } from '../apiClient';
 import { mapUser } from './userMapper';
@@ -7,5 +7,9 @@ import { mapUser } from './userMapper';
 export const userApi = {
   getMe(): Promise<User> {
     return apiClient.get<UserResponse>('/api/users/me').then(mapUser);
+  },
+
+  updateMe(data: UpdateMeRequest): Promise<User> {
+    return apiClient.patch<UserResponse>('/api/users/me', data).then(mapUser);
   },
 };

--- a/src/app/api/_lib/auth.test.ts
+++ b/src/app/api/_lib/auth.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createServerClient } from '@/lib/supabase/server';
 import { getOrCreateUserByAuthUser } from '@/app/api/_lib/current-user';
 
-import { requireActiveUser } from './auth';
+import { requireActiveUser, requireAdmin, requireSeller } from './auth';
 
 vi.mock('@/lib/supabase/server');
 vi.mock('@/app/api/_lib/current-user');
@@ -19,9 +19,23 @@ const mockServiceUser = {
   updatedAt: '2026-01-01T00:00:00Z',
 };
 
-function makeSupabaseClient(user: unknown) {
+function makeSupabaseClient(
+  user: unknown,
+  storeResult?: { data: unknown; error: unknown }
+) {
   return {
     auth: { getUser: vi.fn().mockResolvedValue({ data: { user } }) },
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi
+            .fn()
+            .mockResolvedValue(
+              storeResult ?? { data: null, error: { code: 'PGRST116' } }
+            ),
+        }),
+      }),
+    }),
   };
 }
 
@@ -89,5 +103,134 @@ describe('requireActiveUser', () => {
       code: 'FORBIDDEN',
       statusCode: 403,
     });
+  });
+});
+
+describe('requireSeller', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function setupUser(role: 'customer' | 'seller' | 'admin') {
+    vi.mocked(getOrCreateUserByAuthUser).mockResolvedValue({
+      ...mockServiceUser,
+      role,
+    });
+  }
+
+  it('role이 customer면 FORBIDDEN을 던진다', async () => {
+    vi.mocked(createServerClient).mockResolvedValue(
+      makeSupabaseClient(mockAuthUser) as unknown as Awaited<
+        ReturnType<typeof createServerClient>
+      >
+    );
+    setupUser('customer');
+
+    await expect(requireSeller()).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      statusCode: 403,
+    });
+  });
+
+  it('role이 admin이면 FORBIDDEN을 던진다', async () => {
+    vi.mocked(createServerClient).mockResolvedValue(
+      makeSupabaseClient(mockAuthUser) as unknown as Awaited<
+        ReturnType<typeof createServerClient>
+      >
+    );
+    setupUser('admin');
+
+    await expect(requireSeller()).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      statusCode: 403,
+    });
+  });
+
+  it('seller이고 store가 없으면 STORE_NOT_FOUND를 던진다', async () => {
+    vi.mocked(createServerClient).mockResolvedValue(
+      makeSupabaseClient(mockAuthUser, {
+        data: null,
+        error: { code: 'PGRST116' },
+      }) as unknown as Awaited<ReturnType<typeof createServerClient>>
+    );
+    setupUser('seller');
+
+    await expect(requireSeller()).rejects.toMatchObject({
+      code: 'STORE_NOT_FOUND',
+      statusCode: 404,
+    });
+  });
+
+  it.each(['pending', 'rejected', 'inactive'] as const)(
+    'seller이고 store status가 %s면 STORE_NOT_APPROVED를 던진다',
+    async (status) => {
+      vi.mocked(createServerClient).mockResolvedValue(
+        makeSupabaseClient(mockAuthUser, {
+          data: { id: 'store-1', status },
+          error: null,
+        }) as unknown as Awaited<ReturnType<typeof createServerClient>>
+      );
+      setupUser('seller');
+
+      await expect(requireSeller()).rejects.toMatchObject({
+        code: 'STORE_NOT_APPROVED',
+        statusCode: 403,
+      });
+    }
+  );
+
+  it('seller이고 approved store가 있으면 결과를 반환한다', async () => {
+    vi.mocked(createServerClient).mockResolvedValue(
+      makeSupabaseClient(mockAuthUser, {
+        data: { id: 'store-1', status: 'approved' },
+        error: null,
+      }) as unknown as Awaited<ReturnType<typeof createServerClient>>
+    );
+    setupUser('seller');
+
+    const result = await requireSeller();
+    expect(result.serviceUser.role).toBe('seller');
+    expect(result.store).toEqual({ id: 'store-1' });
+  });
+});
+
+describe('requireAdmin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function setupUser(role: 'customer' | 'seller' | 'admin') {
+    vi.mocked(createServerClient).mockResolvedValue(
+      makeSupabaseClient(mockAuthUser) as unknown as Awaited<
+        ReturnType<typeof createServerClient>
+      >
+    );
+    vi.mocked(getOrCreateUserByAuthUser).mockResolvedValue({
+      ...mockServiceUser,
+      role,
+    });
+  }
+
+  it('role이 customer면 FORBIDDEN을 던진다', async () => {
+    setupUser('customer');
+    await expect(requireAdmin()).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      statusCode: 403,
+    });
+  });
+
+  it('role이 seller면 FORBIDDEN을 던진다', async () => {
+    setupUser('seller');
+    await expect(requireAdmin()).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      statusCode: 403,
+    });
+  });
+
+  it('role이 admin이면 authUser와 serviceUser를 반환한다', async () => {
+    setupUser('admin');
+    const result = await requireAdmin();
+    expect(result.authUser).toBe(mockAuthUser);
+    expect(result.serviceUser.role).toBe('admin');
   });
 });

--- a/src/app/api/_lib/auth.test.ts
+++ b/src/app/api/_lib/auth.test.ts
@@ -146,6 +146,21 @@ describe('requireSeller', () => {
     });
   });
 
+  it('seller이고 store 조회에서 PGRST116 외 에러면 INTERNAL_SERVER_ERROR를 던진다', async () => {
+    vi.mocked(createServerClient).mockResolvedValue(
+      makeSupabaseClient(mockAuthUser, {
+        data: null,
+        error: { code: '42501' },
+      }) as unknown as Awaited<ReturnType<typeof createServerClient>>
+    );
+    setupUser('seller');
+
+    await expect(requireSeller()).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      statusCode: 500,
+    });
+  });
+
   it('seller이고 store가 없으면 STORE_NOT_FOUND를 던진다', async () => {
     vi.mocked(createServerClient).mockResolvedValue(
       makeSupabaseClient(mockAuthUser, {

--- a/src/app/api/_lib/auth.ts
+++ b/src/app/api/_lib/auth.ts
@@ -33,12 +33,46 @@ export async function requireActiveUser(): Promise<{
   return { authUser, serviceUser };
 }
 
-export async function requireSeller() {
-  // Phase 4에서 DB role 조회로 보강
-  return requireAuth();
+type RequireSellerResult = {
+  authUser: User;
+  serviceUser: UserResponse;
+  store: { id: string };
+};
+
+export async function requireSeller(): Promise<RequireSellerResult> {
+  const { authUser, serviceUser } = await requireActiveUser();
+
+  if (serviceUser.role !== 'seller') {
+    throw new AppError(ERROR_CODE.FORBIDDEN, 403);
+  }
+
+  const supabase = await createServerClient();
+  const { data: store, error } = await supabase
+    .from('stores')
+    .select('id, status')
+    .eq('user_id', serviceUser.id)
+    .single();
+
+  if (error || !store) {
+    throw new AppError(ERROR_CODE.STORE_NOT_FOUND, 404);
+  }
+
+  if (store.status !== 'approved') {
+    throw new AppError(ERROR_CODE.STORE_NOT_APPROVED, 403);
+  }
+
+  return { authUser, serviceUser, store: { id: store.id } };
 }
 
-export async function requireAdmin() {
-  // Phase 4에서 DB role 조회로 보강
-  return requireAuth();
+export async function requireAdmin(): Promise<{
+  authUser: User;
+  serviceUser: UserResponse;
+}> {
+  const { authUser, serviceUser } = await requireActiveUser();
+
+  if (serviceUser.role !== 'admin') {
+    throw new AppError(ERROR_CODE.FORBIDDEN, 403);
+  }
+
+  return { authUser, serviceUser };
 }

--- a/src/app/api/_lib/auth.ts
+++ b/src/app/api/_lib/auth.ts
@@ -53,7 +53,14 @@ export async function requireSeller(): Promise<RequireSellerResult> {
     .eq('user_id', serviceUser.id)
     .single();
 
-  if (error || !store) {
+  if (error) {
+    if (error.code === 'PGRST116') {
+      throw new AppError(ERROR_CODE.STORE_NOT_FOUND, 404);
+    }
+    throw new AppError(ERROR_CODE.INTERNAL_SERVER_ERROR, 500);
+  }
+
+  if (!store) {
     throw new AppError(ERROR_CODE.STORE_NOT_FOUND, 404);
   }
 

--- a/src/app/api/users/me/_lib/schemas.test.ts
+++ b/src/app/api/users/me/_lib/schemas.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { updateMeSchema } from './schemas';
+
+describe('updateMeSchema', () => {
+  it('빈 object는 refine 실패한다', () => {
+    const result = updateMeSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('name이 빈 문자열이면 실패한다', () => {
+    const result = updateMeSchema.safeParse({ name: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('name이 공백만 있으면 trim 후 min(1) 실패한다', () => {
+    const result = updateMeSchema.safeParse({ name: '   ' });
+    expect(result.success).toBe(false);
+  });
+
+  it('name 앞뒤 공백은 trim되어 통과한다', () => {
+    const result = updateMeSchema.safeParse({ name: ' 홍길동 ' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe('홍길동');
+    }
+  });
+
+  it('101자 name은 max(100) 실패한다', () => {
+    const result = updateMeSchema.safeParse({ name: 'a'.repeat(101) });
+    expect(result.success).toBe(false);
+  });
+
+  it('100자 name은 통과한다', () => {
+    const result = updateMeSchema.safeParse({ name: 'a'.repeat(100) });
+    expect(result.success).toBe(true);
+  });
+
+  it('유효한 name이면 통과한다', () => {
+    const result = updateMeSchema.safeParse({ name: '홍길동' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe('홍길동');
+    }
+  });
+});

--- a/src/app/api/users/me/_lib/schemas.ts
+++ b/src/app/api/users/me/_lib/schemas.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const updateMeSchema = z
+  .object({
+    name: z.string().trim().min(1).max(100).optional(),
+  })
+  .refine((data) => Object.values(data).some((v) => v !== undefined), {
+    message: '수정할 필드가 하나 이상 있어야 합니다.',
+  });
+
+export type UpdateMeBody = z.infer<typeof updateMeSchema>;

--- a/src/app/api/users/me/_lib/service.test.ts
+++ b/src/app/api/users/me/_lib/service.test.ts
@@ -1,5 +1,7 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { Database } from '@/lib/supabase/database';
 import { mapUserRow } from '@/app/api/users/_lib/mapper';
 
 import { updateUser } from './service';
@@ -42,7 +44,7 @@ function makeClient(result: {
         }),
       }),
     }),
-  };
+  } as unknown as SupabaseClient<Database>;
 }
 
 describe('updateUser', () => {

--- a/src/app/api/users/me/_lib/service.test.ts
+++ b/src/app/api/users/me/_lib/service.test.ts
@@ -34,10 +34,13 @@ function makeServiceClient(result: {
   data: typeof mockRow | null;
   error: { code: string } | null;
 }) {
-  return {
+  const updateFn = vi.fn();
+  const eqFn = vi.fn();
+
+  const client = {
     from: () => ({
-      update: () => ({
-        eq: () => ({
+      update: updateFn.mockReturnValue({
+        eq: eqFn.mockReturnValue({
           select: () => ({
             single: () => Promise.resolve(result),
           }),
@@ -45,6 +48,8 @@ function makeServiceClient(result: {
       }),
     }),
   };
+
+  return { client, updateFn, eqFn };
 }
 
 describe('updateUser', () => {
@@ -53,24 +58,28 @@ describe('updateUser', () => {
     vi.mocked(mapUserRow).mockReturnValue(mockUserResponse);
   });
 
-  it('업데이트 성공 시 mapUserRow 결과를 반환한다', async () => {
+  it('업데이트 성공 시 올바른 인자로 update/eq를 호출하고 mapUserRow 결과를 반환한다', async () => {
+    const { client, updateFn, eqFn } = makeServiceClient({
+      data: mockRow,
+      error: null,
+    });
     vi.mocked(createServiceRoleClient).mockReturnValue(
-      makeServiceClient({
-        data: mockRow,
-        error: null,
-      }) as unknown as ReturnType<typeof createServiceRoleClient>
+      client as unknown as ReturnType<typeof createServiceRoleClient>
     );
     const result = await updateUser('user-1', { name: '홍길동' });
+    expect(updateFn).toHaveBeenCalledWith({ name: '홍길동' });
+    expect(eqFn).toHaveBeenCalledWith('id', 'user-1');
     expect(mapUserRow).toHaveBeenCalledWith(mockRow);
     expect(result).toBe(mockUserResponse);
   });
 
   it('PGRST116 에러면 NOT_FOUND를 던진다', async () => {
+    const { client } = makeServiceClient({
+      data: null,
+      error: { code: 'PGRST116' },
+    });
     vi.mocked(createServiceRoleClient).mockReturnValue(
-      makeServiceClient({
-        data: null,
-        error: { code: 'PGRST116' },
-      }) as unknown as ReturnType<typeof createServiceRoleClient>
+      client as unknown as ReturnType<typeof createServiceRoleClient>
     );
     await expect(
       updateUser('user-1', { name: '홍길동' })
@@ -81,11 +90,12 @@ describe('updateUser', () => {
   });
 
   it('기타 Supabase 에러면 INTERNAL_SERVER_ERROR를 던진다', async () => {
+    const { client } = makeServiceClient({
+      data: null,
+      error: { code: '42501' },
+    });
     vi.mocked(createServiceRoleClient).mockReturnValue(
-      makeServiceClient({
-        data: null,
-        error: { code: '42501' },
-      }) as unknown as ReturnType<typeof createServiceRoleClient>
+      client as unknown as ReturnType<typeof createServiceRoleClient>
     );
     await expect(
       updateUser('user-1', { name: '홍길동' })

--- a/src/app/api/users/me/_lib/service.test.ts
+++ b/src/app/api/users/me/_lib/service.test.ts
@@ -1,11 +1,11 @@
-import type { SupabaseClient } from '@supabase/supabase-js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { Database } from '@/lib/supabase/database';
+import { createServiceRoleClient } from '@/lib/supabase/service';
 import { mapUserRow } from '@/app/api/users/_lib/mapper';
 
 import { updateUser } from './service';
 
+vi.mock('@/lib/supabase/service');
 vi.mock('@/app/api/users/_lib/mapper');
 
 const mockRow = {
@@ -30,7 +30,7 @@ const mockUserResponse = {
   updatedAt: '2026-01-01T00:00:00Z',
 };
 
-function makeClient(result: {
+function makeServiceClient(result: {
   data: typeof mockRow | null;
   error: { code: string } | null;
 }) {
@@ -44,7 +44,7 @@ function makeClient(result: {
         }),
       }),
     }),
-  } as unknown as SupabaseClient<Database>;
+  };
 }
 
 describe('updateUser', () => {
@@ -54,16 +54,26 @@ describe('updateUser', () => {
   });
 
   it('업데이트 성공 시 mapUserRow 결과를 반환한다', async () => {
-    const client = makeClient({ data: mockRow, error: null });
-    const result = await updateUser(client, 'user-1', { name: '홍길동' });
+    vi.mocked(createServiceRoleClient).mockReturnValue(
+      makeServiceClient({
+        data: mockRow,
+        error: null,
+      }) as unknown as ReturnType<typeof createServiceRoleClient>
+    );
+    const result = await updateUser('user-1', { name: '홍길동' });
     expect(mapUserRow).toHaveBeenCalledWith(mockRow);
     expect(result).toBe(mockUserResponse);
   });
 
   it('PGRST116 에러면 NOT_FOUND를 던진다', async () => {
-    const client = makeClient({ data: null, error: { code: 'PGRST116' } });
+    vi.mocked(createServiceRoleClient).mockReturnValue(
+      makeServiceClient({
+        data: null,
+        error: { code: 'PGRST116' },
+      }) as unknown as ReturnType<typeof createServiceRoleClient>
+    );
     await expect(
-      updateUser(client, 'user-1', { name: '홍길동' })
+      updateUser('user-1', { name: '홍길동' })
     ).rejects.toMatchObject({
       code: 'NOT_FOUND',
       statusCode: 404,
@@ -71,9 +81,14 @@ describe('updateUser', () => {
   });
 
   it('기타 Supabase 에러면 INTERNAL_SERVER_ERROR를 던진다', async () => {
-    const client = makeClient({ data: null, error: { code: '42501' } });
+    vi.mocked(createServiceRoleClient).mockReturnValue(
+      makeServiceClient({
+        data: null,
+        error: { code: '42501' },
+      }) as unknown as ReturnType<typeof createServiceRoleClient>
+    );
     await expect(
-      updateUser(client, 'user-1', { name: '홍길동' })
+      updateUser('user-1', { name: '홍길동' })
     ).rejects.toMatchObject({
       code: 'INTERNAL_SERVER_ERROR',
       statusCode: 500,

--- a/src/app/api/users/me/_lib/service.test.ts
+++ b/src/app/api/users/me/_lib/service.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mapUserRow } from '@/app/api/users/_lib/mapper';
+
+import { updateUser } from './service';
+
+vi.mock('@/app/api/users/_lib/mapper');
+
+const mockRow = {
+  id: 'user-1',
+  email: 'test@example.com',
+  name: '홍길동',
+  phone: null,
+  profile_image: null,
+  role: 'customer' as const,
+  status: 'active' as const,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const mockUserResponse = {
+  id: 'user-1',
+  email: 'test@example.com',
+  name: '홍길동',
+  role: 'customer' as const,
+  status: 'active' as const,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+function makeClient(result: {
+  data: typeof mockRow | null;
+  error: { code: string } | null;
+}) {
+  return {
+    from: () => ({
+      update: () => ({
+        eq: () => ({
+          select: () => ({
+            single: () => Promise.resolve(result),
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+describe('updateUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(mapUserRow).mockReturnValue(mockUserResponse);
+  });
+
+  it('업데이트 성공 시 mapUserRow 결과를 반환한다', async () => {
+    const client = makeClient({ data: mockRow, error: null });
+    const result = await updateUser(client, 'user-1', { name: '홍길동' });
+    expect(mapUserRow).toHaveBeenCalledWith(mockRow);
+    expect(result).toBe(mockUserResponse);
+  });
+
+  it('PGRST116 에러면 NOT_FOUND를 던진다', async () => {
+    const client = makeClient({ data: null, error: { code: 'PGRST116' } });
+    await expect(
+      updateUser(client, 'user-1', { name: '홍길동' })
+    ).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      statusCode: 404,
+    });
+  });
+
+  it('기타 Supabase 에러면 INTERNAL_SERVER_ERROR를 던진다', async () => {
+    const client = makeClient({ data: null, error: { code: '42501' } });
+    await expect(
+      updateUser(client, 'user-1', { name: '홍길동' })
+    ).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      statusCode: 500,
+    });
+  });
+});

--- a/src/app/api/users/me/_lib/service.ts
+++ b/src/app/api/users/me/_lib/service.ts
@@ -1,18 +1,17 @@
-import type { SupabaseClient } from '@supabase/supabase-js';
-
 import type { UserResponse } from '@/contracts/user';
 import { AppError } from '@/lib/errors/appError';
 import { ERROR_CODE } from '@/lib/errors/errorCodes';
-import type { Database } from '@/lib/supabase/database';
+import { createServiceRoleClient } from '@/lib/supabase/service';
 import { mapUserRow } from '@/app/api/users/_lib/mapper';
 
 import type { UpdateMeBody } from './schemas';
 
 export async function updateUser(
-  supabase: SupabaseClient<Database>,
   userId: string,
   data: UpdateMeBody
 ): Promise<UserResponse> {
+  const supabase = createServiceRoleClient();
+
   const { data: updated, error } = await supabase
     .from('users')
     .update(data)

--- a/src/app/api/users/me/_lib/service.ts
+++ b/src/app/api/users/me/_lib/service.ts
@@ -1,0 +1,54 @@
+import type { UserResponse } from '@/contracts/user';
+import { AppError } from '@/lib/errors/appError';
+import { ERROR_CODE } from '@/lib/errors/errorCodes';
+import type { Database } from '@/lib/supabase/database';
+import { mapUserRow } from '@/app/api/users/_lib/mapper';
+
+import type { UpdateMeBody } from './schemas';
+
+type UsersRow = Database['public']['Tables']['users']['Row'];
+type UpdatePayload = Partial<Database['public']['Tables']['users']['Update']>;
+
+interface MinimalClient {
+  from(table: 'users'): {
+    update(values: UpdatePayload): {
+      eq(
+        column: string,
+        value: string
+      ): {
+        select(columns: string): {
+          single(): Promise<{
+            data: UsersRow | null;
+            error: { code: string } | null;
+          }>;
+        };
+      };
+    };
+  };
+}
+
+export async function updateUser(
+  supabase: MinimalClient,
+  userId: string,
+  data: UpdateMeBody
+): Promise<UserResponse> {
+  const { data: updated, error } = await supabase
+    .from('users')
+    .update(data)
+    .eq('id', userId)
+    .select('*')
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      throw new AppError(ERROR_CODE.NOT_FOUND, 404);
+    }
+    throw new AppError(ERROR_CODE.INTERNAL_SERVER_ERROR, 500);
+  }
+
+  if (!updated) {
+    throw new AppError(ERROR_CODE.NOT_FOUND, 404);
+  }
+
+  return mapUserRow(updated);
+}

--- a/src/app/api/users/me/_lib/service.ts
+++ b/src/app/api/users/me/_lib/service.ts
@@ -1,3 +1,5 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
 import type { UserResponse } from '@/contracts/user';
 import { AppError } from '@/lib/errors/appError';
 import { ERROR_CODE } from '@/lib/errors/errorCodes';
@@ -6,29 +8,8 @@ import { mapUserRow } from '@/app/api/users/_lib/mapper';
 
 import type { UpdateMeBody } from './schemas';
 
-type UsersRow = Database['public']['Tables']['users']['Row'];
-type UpdatePayload = Partial<Database['public']['Tables']['users']['Update']>;
-
-interface MinimalClient {
-  from(table: 'users'): {
-    update(values: UpdatePayload): {
-      eq(
-        column: string,
-        value: string
-      ): {
-        select(columns: string): {
-          single(): Promise<{
-            data: UsersRow | null;
-            error: { code: string } | null;
-          }>;
-        };
-      };
-    };
-  };
-}
-
 export async function updateUser(
-  supabase: MinimalClient,
+  supabase: SupabaseClient<Database>,
   userId: string,
   data: UpdateMeBody
 ): Promise<UserResponse> {

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,6 +1,5 @@
 import type { NextRequest } from 'next/server';
 
-import { createServerClient } from '@/lib/supabase/server';
 import { requireActiveUser } from '@/app/api/_lib/auth';
 import { isApiMockEnabled } from '@/app/api/_lib/mock';
 import { routeError, success } from '@/app/api/_lib/response';
@@ -36,8 +35,7 @@ export async function PATCH(req: NextRequest): Promise<Response> {
   try {
     const { serviceUser } = await requireActiveUser();
     const data = await validateBody(updateMeSchema, req);
-    const supabase = await createServerClient();
-    const updated = await updateUser(supabase, serviceUser.id, data);
+    const updated = await updateUser(serviceUser.id, data);
     return success(updated);
   } catch (e) {
     return routeError(e);

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,7 +1,14 @@
+import type { NextRequest } from 'next/server';
+
+import { createServerClient } from '@/lib/supabase/server';
 import { requireActiveUser } from '@/app/api/_lib/auth';
 import { isApiMockEnabled } from '@/app/api/_lib/mock';
 import { routeError, success } from '@/app/api/_lib/response';
+import { validateBody } from '@/app/api/_lib/validation';
 import { mockUser } from '@/mocks/users';
+
+import { updateMeSchema } from './_lib/schemas';
+import { updateUser } from './_lib/service';
 
 export async function GET(): Promise<Response> {
   if (isApiMockEnabled()) {
@@ -11,6 +18,27 @@ export async function GET(): Promise<Response> {
   try {
     const { serviceUser } = await requireActiveUser();
     return success(serviceUser);
+  } catch (e) {
+    return routeError(e);
+  }
+}
+
+export async function PATCH(req: NextRequest): Promise<Response> {
+  if (isApiMockEnabled()) {
+    try {
+      const data = await validateBody(updateMeSchema, req);
+      return success({ ...mockUser, ...data });
+    } catch (e) {
+      return routeError(e);
+    }
+  }
+
+  try {
+    const { serviceUser } = await requireActiveUser();
+    const data = await validateBody(updateMeSchema, req);
+    const supabase = await createServerClient();
+    const updated = await updateUser(supabase, serviceUser.id, data);
+    return success(updated);
   } catch (e) {
     return routeError(e);
   }

--- a/src/contracts/user.ts
+++ b/src/contracts/user.ts
@@ -9,3 +9,7 @@ export interface UserResponse {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface UpdateMeRequest {
+  name?: string;
+}

--- a/src/hooks/users/useUpdateMe.ts
+++ b/src/hooks/users/useUpdateMe.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type { User } from '@/types/user';
+import type { UpdateMeRequest } from '@/contracts/user';
+import { userApi } from '@/api/users/userApi';
+
+export function useUpdateMe() {
+  const queryClient = useQueryClient();
+
+  return useMutation<User, Error, UpdateMeRequest>({
+    mutationFn: (data) => userApi.updateMe(data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['users', 'me'] });
+    },
+  });
+}


### PR DESCRIPTION
## 📌 작업 내용

- `PATCH /api/users/me` API 구현
- `requireSeller()`, `requireAdmin()` 헬퍼 구현
> 현재 사용자 정보 수정은 name 필드만 가능합니다

## 🔧 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서 수정

## 📂 주요 변경 파일

- `src/app/api/users/me/route.ts`
- `src/app/api/_lib/auth.ts`

## 🧪 테스트 방법

- 테스트 페이지 구현 후 `npm run dev` 실행

## 🔗 관련 이슈

- closes #43 
