### PR TITLE
feat: 상품 상세 예약 패널 기능 구현

### DIFF
--- a/src/app/(consumer)/products/[productId]/page.tsx
+++ b/src/app/(consumer)/products/[productId]/page.tsx
@@ -81,7 +81,13 @@ export default async function ProductDetailPage({
           </div>
 
           <aside className="lg:sticky lg:top-24 lg:self-start">
-            <ProductReservationPanel price={product.discountPrice} />
+            <ProductReservationPanel
+              productId={product.id}
+              price={product.discountPrice}
+              availableStock={product.availableStock}
+              pickupStartTime={product.pickupStartTime}
+              pickupEndTime={product.pickupEndTime}
+            />
           </aside>
         </section>
 

--- a/src/app/(consumer)/products/[productId]/page.tsx
+++ b/src/app/(consumer)/products/[productId]/page.tsx
@@ -82,7 +82,6 @@ export default async function ProductDetailPage({
 
           <aside className="lg:sticky lg:top-24 lg:self-start">
             <ProductReservationPanel
-              productId={product.id}
               price={product.discountPrice}
               availableStock={product.availableStock}
               pickupStartTime={product.pickupStartTime}

--- a/src/components/consumer/ProductReservationPanel.tsx
+++ b/src/components/consumer/ProductReservationPanel.tsx
@@ -128,20 +128,15 @@ export function ProductReservationPanel({
     () => createPickupTimeSlots(pickupStartTime, pickupEndTime),
     [pickupStartTime, pickupEndTime]
   );
-  const [selectedTimeSlot, setSelectedTimeSlot] = useState(
-    timeSlots[0]?.value ?? ''
-  );
+  const [selectedTimeSlot, setSelectedTimeSlot] = useState('');
 
-  const firstAvailableTimeSlot = timeSlots.find(
-    (slot) => !isPastTimeSlot(slot.value, pickupStartTime, now)
-  );
   const selectedSlot = timeSlots.find(
     (slot) => slot.value === selectedTimeSlot
   );
   const activeTimeSlot =
     selectedSlot && !isPastTimeSlot(selectedSlot.value, pickupStartTime, now)
       ? selectedSlot.value
-      : (firstAvailableTimeSlot?.value ?? '');
+      : '';
 
   const [quantity, setQuantity] = useState(() => (availableStock > 0 ? 1 : 0));
 
@@ -150,6 +145,19 @@ export function ProductReservationPanel({
   };
   const handleIncreaseQuantity = () => {
     setQuantity((current) => Math.min(availableStock, current + 1));
+  };
+  const handleAddButtonClick = () => {
+    if (
+      activeTimeSlot === '' ||
+      availableStock <= 0 ||
+      quantity <= 0 ||
+      isPastTimeSlot(activeTimeSlot, pickupStartTime, new Date())
+    ) {
+      setSelectedTimeSlot('');
+      return;
+    }
+
+    // TODO: 주문/결제 플로우 연동 시 선택한 픽업 시간과 수량을 전달합니다.
   };
   const isDecreaseDisabled = quantity <= 1;
   const isIncreaseDisabled = quantity >= availableStock;
@@ -247,6 +255,7 @@ export function ProductReservationPanel({
       <Button
         disabled={isAddButtonDisabled}
         className="w-full py-3 text-xl font-extrabold"
+        onClick={handleAddButtonClick}
       >
         {availableStock <= 0
           ? '예약 불가'

--- a/src/components/consumer/ProductReservationPanel.tsx
+++ b/src/components/consumer/ProductReservationPanel.tsx
@@ -12,7 +12,6 @@ import { useMemo, useState } from 'react';
 import { Button } from '@/components/common';
 
 interface ProductReservationPanelProps {
-  productId: string;
   price: number;
   availableStock: number;
   pickupStartTime: string;
@@ -146,10 +145,10 @@ export function ProductReservationPanel({
 
   const [quantity, setQuantity] = useState(() => (availableStock > 0 ? 1 : 0));
 
-  const decreaseQuantity = () => {
+  const handleDecreaseQuantity = () => {
     setQuantity((current) => Math.max(1, current - 1));
   };
-  const increaseQuantity = () => {
+  const handleIncreaseQuantity = () => {
     setQuantity((current) => Math.min(availableStock, current + 1));
   };
   const isDecreaseDisabled = quantity <= 1;
@@ -226,7 +225,7 @@ export function ProductReservationPanel({
             aria-label="수량 감소"
             disabled={isDecreaseDisabled}
             className="px-4 py-2 text-gray-600 disabled:text-gray-300"
-            onClick={decreaseQuantity}
+            onClick={handleDecreaseQuantity}
           >
             <Minus className="size-4" aria-hidden="true" />
           </button>
@@ -238,7 +237,7 @@ export function ProductReservationPanel({
             aria-label="수량 증가"
             disabled={isIncreaseDisabled}
             className="px-4 py-2 text-gray-600 disabled:text-gray-300"
-            onClick={increaseQuantity}
+            onClick={handleIncreaseQuantity}
           >
             <Plus className="size-4" aria-hidden="true" />
           </button>

--- a/src/components/consumer/ProductReservationPanel.tsx
+++ b/src/components/consumer/ProductReservationPanel.tsx
@@ -1,46 +1,271 @@
+'use client';
+
+import {
+  ChevronLeft,
+  ChevronRight,
+  Minus,
+  Plus,
+  ShieldCheck,
+} from 'lucide-react';
+import { useMemo, useState } from 'react';
+
 import { Button } from '@/components/common';
 
 interface ProductReservationPanelProps {
+  productId: string;
   price: number;
+  availableStock: number;
+  pickupStartTime: string;
+  pickupEndTime: string;
+}
+
+function formatPickupDate(value: string) {
+  if (!value.includes('T')) {
+    return '오늘';
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return '오늘';
+  }
+
+  return new Intl.DateTimeFormat('ko-KR', {
+    month: 'numeric',
+    day: 'numeric',
+    weekday: 'short',
+  }).format(date);
+}
+
+function createPickupTimeSlots(startTime: string, endTime: string) {
+  const start = parseTimeToMinutes(startTime);
+  const end = parseTimeToMinutes(endTime);
+  const slots: { label: string; value: string }[] = [];
+
+  if (start === null || end === null || start >= end) {
+    return slots;
+  }
+
+  for (let current = start; current + 30 <= end; current += 30) {
+    const next = current + 30;
+    slots.push({
+      value: `${formatMinutesToTime(current)}-${formatMinutesToTime(next)}`,
+      label: `${formatMinutesToTime(current)}~${formatMinutesToTime(next)}`,
+    });
+  }
+
+  return slots;
+}
+
+function parseTimeToMinutes(value: string) {
+  const time = value.includes('T') ? value.split('T')[1] : value;
+  const [hour, minute] = time.split(':').map(Number);
+
+  if (
+    Number.isNaN(hour) ||
+    Number.isNaN(minute) ||
+    hour < 0 ||
+    hour > 23 ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return null;
+  }
+
+  return hour * 60 + minute;
+}
+
+function formatMinutesToTime(totalMinutes: number) {
+  const hour = Math.floor(totalMinutes / 60);
+  const minute = totalMinutes % 60;
+
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+}
+
+function isPastTimeSlot(slotValue: string, pickupDateTime: string, now: Date) {
+  const [startTime] = slotValue.split('-');
+  const slotStartMinutes = parseTimeToMinutes(startTime);
+
+  if (slotStartMinutes === null) {
+    return true;
+  }
+
+  if (pickupDateTime.includes('T')) {
+    const pickupDate = new Date(pickupDateTime);
+
+    if (Number.isNaN(pickupDate.getTime())) {
+      return true;
+    }
+
+    const pickupDateOnly = new Date(
+      pickupDate.getFullYear(),
+      pickupDate.getMonth(),
+      pickupDate.getDate()
+    );
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+    if (pickupDateOnly.getTime() > today.getTime()) {
+      return false;
+    }
+
+    if (pickupDateOnly.getTime() < today.getTime()) {
+      return true;
+    }
+  }
+
+  const nowMinutes = now.getHours() * 60 + now.getMinutes();
+
+  return slotStartMinutes <= nowMinutes;
 }
 
 export function ProductReservationPanel({
   price,
+  availableStock,
+  pickupStartTime,
+  pickupEndTime,
 }: ProductReservationPanelProps) {
+  const [now] = useState(() => new Date());
+  const timeSlots = useMemo(
+    () => createPickupTimeSlots(pickupStartTime, pickupEndTime),
+    [pickupStartTime, pickupEndTime]
+  );
+  const [selectedTimeSlot, setSelectedTimeSlot] = useState(
+    timeSlots[0]?.value ?? ''
+  );
+
+  const firstAvailableTimeSlot = timeSlots.find(
+    (slot) => !isPastTimeSlot(slot.value, pickupStartTime, now)
+  );
+  const selectedSlot = timeSlots.find(
+    (slot) => slot.value === selectedTimeSlot
+  );
+  const activeTimeSlot =
+    selectedSlot && !isPastTimeSlot(selectedSlot.value, pickupStartTime, now)
+      ? selectedSlot.value
+      : (firstAvailableTimeSlot?.value ?? '');
+
+  const [quantity, setQuantity] = useState(() => (availableStock > 0 ? 1 : 0));
+
+  const decreaseQuantity = () => {
+    setQuantity((current) => Math.max(1, current - 1));
+  };
+  const increaseQuantity = () => {
+    setQuantity((current) => Math.min(availableStock, current + 1));
+  };
+  const isDecreaseDisabled = quantity <= 1;
+  const isIncreaseDisabled = quantity >= availableStock;
+  const isAddButtonDisabled =
+    activeTimeSlot === '' || availableStock <= 0 || quantity <= 0;
+
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6">
       <h2 className="mb-4 text-lg font-bold text-gray-900">
         픽업 날짜 및 시간 선택
       </h2>
+      <div className="flex items-center justify-between rounded-md border border-gray-200 px-4 py-3">
+        <button
+          type="button"
+          aria-label="이전 날짜"
+          disabled
+          className="text-gray-300 disabled:cursor-not-allowed"
+        >
+          <ChevronLeft />
+        </button>
 
-      <div className="mb-6 rounded-md border border-gray-200 p-4 text-sm text-gray-600">
-        시간 선택 영역
+        <span className="text-base font-semibold text-gray-900">
+          {formatPickupDate(pickupStartTime)}
+        </span>
+
+        <button
+          type="button"
+          aria-label="다음 날짜"
+          disabled
+          className="text-gray-300 disabled:cursor-not-allowed"
+        >
+          <ChevronRight />
+        </button>
+      </div>
+
+      <div className="mt-3 mb-6 grid max-h-42 grid-cols-3 gap-2 overflow-y-auto pr-1">
+        {timeSlots.map((slot) => {
+          const isSelected = activeTimeSlot === slot.value;
+          const isDisabled = isPastTimeSlot(slot.value, pickupStartTime, now);
+
+          return (
+            <Button
+              key={slot.value}
+              type="button"
+              variant="outline"
+              color={isSelected ? 'primary' : 'gray'}
+              aria-pressed={isSelected}
+              disabled={isDisabled}
+              className={[
+                'h-auto rounded-md px-3 py-3 text-sm',
+                isSelected && !isDisabled ? 'bg-primary-50' : 'bg-white',
+                isDisabled ? 'text-gray-300' : '',
+              ].join(' ')}
+              onClick={() => setSelectedTimeSlot(slot.value)}
+            >
+              {slot.label}
+            </Button>
+          );
+        })}
+
+        {timeSlots.length === 0 ? (
+          <p className="col-span-3 rounded-md border border-gray-200 p-4 text-sm text-gray-500">
+            선택 가능한 픽업 시간이 없습니다.
+          </p>
+        ) : null}
       </div>
 
       <div className="mb-6">
-        <p className="mb-3 text-sm font-semibold text-gray-900">수량 선택</p>
-        <div className="flex w-fit items-center rounded-md border border-gray-200">
+        <p className="mb-3 text-lg font-semibold text-gray-900">수량 선택</p>
+        <div className="flex w-fit overflow-hidden rounded-md border border-gray-200">
           <button
             type="button"
             aria-label="수량 감소"
-            className="px-4 py-2 text-gray-600"
+            disabled={isDecreaseDisabled}
+            className="px-4 py-2 text-gray-600 disabled:text-gray-300"
+            onClick={decreaseQuantity}
           >
-            -
+            <Minus className="size-4" aria-hidden="true" />
           </button>
-          <span className="px-4 py-2 text-sm font-medium">1</span>
+          <span className="flex size-9 items-center justify-center border-x border-gray-200 text-sm font-medium text-gray-900">
+            {quantity}
+          </span>
           <button
             type="button"
             aria-label="수량 증가"
-            className="px-4 py-2 text-gray-600"
+            disabled={isIncreaseDisabled}
+            className="px-4 py-2 text-gray-600 disabled:text-gray-300"
+            onClick={increaseQuantity}
           >
-            +
+            <Plus className="size-4" aria-hidden="true" />
           </button>
         </div>
       </div>
 
-      <Button className="w-full py-3 text-sm font-bold">
-        {price.toLocaleString()}원 담기
+      <Button
+        disabled={isAddButtonDisabled}
+        className="w-full py-3 text-xl font-extrabold"
+      >
+        {availableStock <= 0
+          ? '예약 불가'
+          : `${(price * quantity).toLocaleString()}원 담기`}
       </Button>
+
+      <div className="mt-7 flex gap-3 rounded-md bg-gray-50 p-4">
+        <div className="bg-primary-100 text-primary-500 flex size-9 shrink-0 items-center justify-center rounded-full">
+          <ShieldCheck className="size-5" aria-hidden="true" />
+        </div>
+
+        <div>
+          <p className="text-sm font-bold text-gray-900">픽마 안심 서비스</p>
+          <p className="mt-1 text-xs leading-5 text-gray-500">
+            상품에 문제가 있을 경우 픽마가 100% 환불해드려요.
+          </p>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 📌 작업 내용

- 상품 상세 페이지 우측 예약 패널의 기본 상호작용을 구현했습니다.
- 픽업 가능 시간대를 30분 단위로 나누어 선택할 수 있도록 구성했습니다.
- 수량 선택 기능과 선택 수량에 따른 담기 금액 계산을 추가했습니다.
- 재고/시간 선택 상태에 따라 담기 버튼이 비활성화되도록 처리했습니다.
- 픽마 안심 서비스 안내 영역을 추가했습니다.

## 🔧 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 📂 주요 변경 파일

- `src/components/consumer/ProductReservationPanel.tsx`
- `src/app/(consumer)/products/[productId]/page.tsx`

## 🧪 테스트 방법

- `/products/product_1` 상세 페이지 접속
- 픽업 시간 슬롯이 30분 단위로 렌더링되는지 확인
- 현재 시간보다 지난 시간 슬롯이 disabled 처리되는지 확인
- 수량 증가/감소 버튼 동작 확인
- 수량이 1 미만으로 내려가지 않는지 확인
- 수량이 남은 재고를 초과하지 않는지 확인
- 수량 변경 시 담기 버튼 금액이 변경되는지 확인
- 시간 선택이 없거나 재고가 없는 경우 담기 버튼이 disabled 되는지 확인
- `npm run lint`

## 📸 스크린샷 (선택)

- x

## 🔗 관련 이슈

- close #48

## 📝 참고

- 현재 상품 데이터에는 선택 가능한 날짜 목록이 없어 날짜 이동 기능은 구현하지 않았습니다.
- 이전/다음 날짜 버튼은 UI 위치만 잡고 disabled 상태로 두었습니다.
- 추후 API에서 `pickupDates` 또는 날짜별 픽업 가능 시간 정보가 제공되면 날짜 이동 기능을 연결할 예정입니다.
- 이번 PR에서는 실제 주문 생성/결제 API 연동은 포함하지 않고, 예약 패널의 UI 상태와 기본 상호작용까지만 구현했습니다.
