### PR TITLE
feat: 상품 상세 하단 정보 탭 구현

### DIFF
--- a/src/app/(consumer)/products/[productId]/page.tsx
+++ b/src/app/(consumer)/products/[productId]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation';
 
 import { Footer, Header } from '@/components/common';
 import { ProductDetailInfo } from '@/components/consumer/ProductDetailInfo';
+import { ProductDetailTabs } from '@/components/consumer/ProductDetailTabs';
 import { ProductImageGallery } from '@/components/consumer/ProductImageGallery';
 import { ProductReservationPanel } from '@/components/consumer/ProductReservationPanel';
 import { mockProductDetailsMap } from '@/mocks/products';
@@ -40,47 +41,7 @@ export default async function ProductDetailPage({
           </aside>
         </section>
 
-        <section className="mx-auto max-w-450 px-6 pb-16">
-          <div className="border-b border-gray-200">
-            <nav
-              className="flex gap-10"
-              role="tablist"
-              aria-label="상품 상세 정보"
-            >
-              <button
-                type="button"
-                role="tab"
-                aria-selected="true"
-                className="border-primary-500 text-primary-500 border-b-2 px-2 py-4 text-sm font-semibold"
-              >
-                상세정보
-              </button>
-              <button
-                type="button"
-                role="tab"
-                aria-selected="false"
-                className="px-2 py-4 text-sm font-semibold text-gray-600"
-              >
-                리뷰
-              </button>
-              <button
-                type="button"
-                role="tab"
-                aria-selected="false"
-                className="px-2 py-4 text-sm font-semibold text-gray-600"
-              >
-                매장 정보
-              </button>
-            </nav>
-          </div>
-
-          <div className="py-8">
-            <h2 className="mb-4 text-lg font-bold text-gray-900">상품 안내</h2>
-            <p className="text-sm leading-6 text-gray-700">
-              상품 상세 설명 영역
-            </p>
-          </div>
-        </section>
+        <ProductDetailTabs product={product} />
       </main>
 
       <Footer />

--- a/src/components/consumer/ProductDetailTabs.tsx
+++ b/src/components/consumer/ProductDetailTabs.tsx
@@ -4,18 +4,21 @@ import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react';
 
 import type { ProductDetailResponse } from '@/contracts/product';
 
+type ProductDetailTabId = 'detail' | 'review' | 'store';
+
 interface ProductDetailTabsProps {
   product: ProductDetailResponse;
 }
 
 interface ProductDetailTab {
+  id: ProductDetailTabId;
   label: string;
 }
 
 const productDetailTabs: ProductDetailTab[] = [
-  { label: '상세정보' },
-  { label: '리뷰' },
-  { label: '매장 정보' },
+  { id: 'detail', label: '상세정보' },
+  { id: 'review', label: '리뷰' },
+  { id: 'store', label: '매장 정보' },
 ];
 
 export function ProductDetailTabs({ product }: ProductDetailTabsProps) {
@@ -32,10 +35,10 @@ export function ProductDetailTabs({ product }: ProductDetailTabsProps) {
         >
           {productDetailTabs.map((tab) => (
             <Tab
-              key={tab.label}
+              key={tab.id}
               className={({ selected }) =>
                 [
-                  'border-b-2 px-2 py-4 text-base font-semibold transition focus:outline-none',
+                  'focus-visible:ring-primary-500 rounded-sm border-b-2 px-2 py-4 text-base font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
                   selected
                     ? 'border-primary-500 text-primary-500'
                     : 'border-transparent text-gray-600 hover:text-gray-900',
@@ -48,7 +51,7 @@ export function ProductDetailTabs({ product }: ProductDetailTabsProps) {
         </TabList>
 
         <TabPanels>
-          <TabPanel className="grid gap-10 py-8 focus:outline-none lg:grid-cols-[minmax(0,1fr)_minmax(280px,660px)_minmax(0,1fr)]">
+          <TabPanel className="focus-visible:ring-primary-500 grid gap-10 rounded-sm py-8 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 lg:grid-cols-[minmax(0,1fr)_minmax(280px,660px)_minmax(0,1fr)]">
             <div className="space-y-8">
               <section>
                 <h2 className="mb-4 text-lg font-bold text-gray-900">
@@ -79,7 +82,7 @@ export function ProductDetailTabs({ product }: ProductDetailTabsProps) {
             </section>
           </TabPanel>
 
-          <TabPanel className="py-8 focus:outline-none">
+          <TabPanel className="focus-visible:ring-primary-500 rounded-sm py-8 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2">
             <div className="rounded-md border border-gray-200 bg-gray-50 p-8 text-center">
               <h2 className="text-lg font-bold text-gray-900">리뷰</h2>
               <p className="mt-2 text-sm text-gray-500">
@@ -88,7 +91,7 @@ export function ProductDetailTabs({ product }: ProductDetailTabsProps) {
             </div>
           </TabPanel>
 
-          <TabPanel className="py-8 focus:outline-none">
+          <TabPanel className="focus-visible:ring-primary-500 rounded-sm py-8 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2">
             <section>
               <dl className="grid gap-5 md:grid-cols-2">
                 <div>

--- a/src/components/consumer/ProductDetailTabs.tsx
+++ b/src/components/consumer/ProductDetailTabs.tsx
@@ -1,204 +1,141 @@
 'use client';
 
-import { useRef, useState, type KeyboardEvent } from 'react';
+import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react';
 
 import type { ProductDetailResponse } from '@/contracts/product';
-
-type ProductDetailTabId = 'detail' | 'review' | 'store';
 
 interface ProductDetailTabsProps {
   product: ProductDetailResponse;
 }
 
 interface ProductDetailTab {
-  id: ProductDetailTabId;
   label: string;
 }
 
 const productDetailTabs: ProductDetailTab[] = [
-  { id: 'detail', label: '상세정보' },
-  { id: 'review', label: '리뷰' },
-  { id: 'store', label: '매장 정보' },
+  { label: '상세정보' },
+  { label: '리뷰' },
+  { label: '매장 정보' },
 ];
 
 export function ProductDetailTabs({ product }: ProductDetailTabsProps) {
-  const [selectedTabId, setSelectedTabId] =
-    useState<ProductDetailTabId>('detail');
-  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
-  const selectedTabIndex = productDetailTabs.findIndex(
-    (tab) => tab.id === selectedTabId
-  );
-
   const pickupPlace = product.store.addressDetail
     ? `${product.store.address} ${product.store.addressDetail}`
     : product.store.address;
 
-  const selectTabByIndex = (index: number) => {
-    const nextTab = productDetailTabs[index];
-
-    if (!nextTab) {
-      return;
-    }
-
-    setSelectedTabId(nextTab.id);
-    tabRefs.current[index]?.focus();
-  };
-
-  const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
-    const lastTabIndex = productDetailTabs.length - 1;
-
-    if (event.key === 'ArrowRight') {
-      event.preventDefault();
-      selectTabByIndex(
-        selectedTabIndex === lastTabIndex ? 0 : selectedTabIndex + 1
-      );
-      return;
-    }
-
-    if (event.key === 'ArrowLeft') {
-      event.preventDefault();
-      selectTabByIndex(
-        selectedTabIndex === 0 ? lastTabIndex : selectedTabIndex - 1
-      );
-      return;
-    }
-
-    if (event.key === 'Home') {
-      event.preventDefault();
-      selectTabByIndex(0);
-      return;
-    }
-
-    if (event.key === 'End') {
-      event.preventDefault();
-      selectTabByIndex(lastTabIndex);
-    }
-  };
-
   return (
     <section className="mx-auto max-w-450 px-6">
-      <div className="border-b border-gray-200">
-        <nav className="flex gap-10" role="tablist" aria-label="상품 상세 정보">
-          {productDetailTabs.map((tab, index) => {
-            const isSelected = selectedTabId === tab.id;
-
-            return (
-              <button
-                key={tab.id}
-                ref={(node) => {
-                  tabRefs.current[index] = node;
-                }}
-                id={`product-detail-tab-${tab.id}`}
-                type="button"
-                role="tab"
-                aria-selected={isSelected}
-                aria-controls={`product-detail-panel-${tab.id}`}
-                tabIndex={isSelected ? 0 : -1}
-                className={[
-                  'border-b-2 px-2 py-4 text-base font-semibold transition',
-                  isSelected
+      <TabGroup>
+        <TabList
+          aria-label="상품 상세 정보"
+          className="flex gap-10 border-b border-gray-200"
+        >
+          {productDetailTabs.map((tab) => (
+            <Tab
+              key={tab.label}
+              className={({ selected }) =>
+                [
+                  'border-b-2 px-2 py-4 text-base font-semibold transition focus:outline-none',
+                  selected
                     ? 'border-primary-500 text-primary-500'
                     : 'border-transparent text-gray-600 hover:text-gray-900',
-                ].join(' ')}
-                onClick={() => setSelectedTabId(tab.id)}
-                onKeyDown={handleTabKeyDown}
-              >
-                {tab.label}
-              </button>
-            );
-          })}
-        </nav>
-      </div>
+                ].join(' ')
+              }
+            >
+              {tab.label}
+            </Tab>
+          ))}
+        </TabList>
 
-      <div
-        id="product-detail-panel-detail"
-        role="tabpanel"
-        aria-labelledby="product-detail-tab-detail"
-        tabIndex={0}
-        hidden={selectedTabId !== 'detail'}
-        className="grid gap-10 py-8 lg:grid-cols-[minmax(0,1fr)_minmax(280px,660px)_minmax(0,1fr)]"
-      >
-        <div className="space-y-8">
-          <section>
-            <h2 className="mb-4 text-lg font-bold text-gray-900">상품 안내</h2>
-            <p className="text-sm leading-6 text-gray-700">
-              {product.description ?? '등록된 상품 설명이 없습니다.'}
-            </p>
-          </section>
+        <TabPanels>
+          <TabPanel className="grid gap-10 py-8 focus:outline-none lg:grid-cols-[minmax(0,1fr)_minmax(280px,660px)_minmax(0,1fr)]">
+            <div className="space-y-8">
+              <section>
+                <h2 className="mb-4 text-lg font-bold text-gray-900">
+                  상품 안내
+                </h2>
+                <p className="text-sm leading-6 text-gray-700">
+                  {product.description ?? '등록된 상품 설명이 없습니다.'}
+                </p>
+              </section>
 
-          <section>
-            <h2 className="mb-4 text-lg font-bold text-gray-900">상품 구성</h2>
-            <ul className="list-inside list-disc space-y-2 text-sm text-gray-700">
-              <li>{product.name}</li>
-            </ul>
-          </section>
-        </div>
-
-        <section className="w-full lg:col-start-2">
-          <h2 className="mb-4 text-lg font-bold text-gray-900">영양 정보</h2>
-          <div className="rounded-md border border-gray-200 bg-gray-50 px-4 py-5 text-sm text-gray-500">
-            상품별 영양 정보는 준비 중입니다.
-          </div>
-        </section>
-      </div>
-
-      <div
-        id="product-detail-panel-review"
-        role="tabpanel"
-        aria-labelledby="product-detail-tab-review"
-        tabIndex={0}
-        hidden={selectedTabId !== 'review'}
-        className="py-8"
-      >
-        <div className="rounded-md border border-gray-200 bg-gray-50 p-8 text-center">
-          <h2 className="text-lg font-bold text-gray-900">리뷰</h2>
-          <p className="mt-2 text-sm text-gray-500">
-            리뷰 기능은 추후 제공 예정입니다.
-          </p>
-        </div>
-      </div>
-
-      <div
-        id="product-detail-panel-store"
-        role="tabpanel"
-        aria-labelledby="product-detail-tab-store"
-        tabIndex={0}
-        hidden={selectedTabId !== 'store'}
-        className="py-8"
-      >
-        <section>
-          <dl className="grid gap-5 md:grid-cols-2">
-            <div>
-              <dt className="mb-1 text-base font-bold text-gray-900">매장명</dt>
-              <dd className="text-sm text-gray-900">{product.store.name}</dd>
+              <section>
+                <h2 className="mb-4 text-lg font-bold text-gray-900">
+                  상품 구성
+                </h2>
+                <ul className="list-inside list-disc space-y-2 text-sm text-gray-700">
+                  <li>{product.name}</li>
+                </ul>
+              </section>
             </div>
-            <div>
-              <dt className="mb-1 text-base font-bold text-gray-900">
-                전화번호
-              </dt>
-              <dd className="text-sm text-gray-900">{product.store.phone}</dd>
-            </div>
-            <div>
-              <dt className="mb-1 text-base font-bold text-gray-900">지역</dt>
-              <dd className="text-sm text-gray-900">{product.store.region}</dd>
-            </div>
-            <div>
-              <dt className="mb-1 text-base font-bold text-gray-900">주소</dt>
-              <dd className="text-sm text-gray-900">{pickupPlace}</dd>
-            </div>
-            {product.store.description ? (
-              <div className="md:col-span-2">
-                <dt className="mb-1 text-base font-bold text-gray-900">
-                  매장 소개
-                </dt>
-                <dd className="text-sm text-gray-900">
-                  {product.store.description}
-                </dd>
+
+            <section className="w-full lg:col-start-2">
+              <h2 className="mb-4 text-lg font-bold text-gray-900">
+                영양 정보
+              </h2>
+              <div className="rounded-md border border-gray-200 bg-gray-50 px-4 py-5 text-sm text-gray-500">
+                상품별 영양 정보는 준비 중입니다.
               </div>
-            ) : null}
-          </dl>
-        </section>
-      </div>
+            </section>
+          </TabPanel>
+
+          <TabPanel className="py-8 focus:outline-none">
+            <div className="rounded-md border border-gray-200 bg-gray-50 p-8 text-center">
+              <h2 className="text-lg font-bold text-gray-900">리뷰</h2>
+              <p className="mt-2 text-sm text-gray-500">
+                리뷰 기능은 추후 제공 예정입니다.
+              </p>
+            </div>
+          </TabPanel>
+
+          <TabPanel className="py-8 focus:outline-none">
+            <section>
+              <dl className="grid gap-5 md:grid-cols-2">
+                <div>
+                  <dt className="mb-1 text-base font-bold text-gray-900">
+                    매장명
+                  </dt>
+                  <dd className="text-sm text-gray-900">
+                    {product.store.name}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="mb-1 text-base font-bold text-gray-900">
+                    전화번호
+                  </dt>
+                  <dd className="text-sm text-gray-900">
+                    {product.store.phone}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="mb-1 text-base font-bold text-gray-900">
+                    지역
+                  </dt>
+                  <dd className="text-sm text-gray-900">
+                    {product.store.region}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="mb-1 text-base font-bold text-gray-900">
+                    주소
+                  </dt>
+                  <dd className="text-sm text-gray-900">{pickupPlace}</dd>
+                </div>
+                {product.store.description ? (
+                  <div className="md:col-span-2">
+                    <dt className="mb-1 text-base font-bold text-gray-900">
+                      매장 소개
+                    </dt>
+                    <dd className="text-sm text-gray-900">
+                      {product.store.description}
+                    </dd>
+                  </div>
+                ) : null}
+              </dl>
+            </section>
+          </TabPanel>
+        </TabPanels>
+      </TabGroup>
     </section>
   );
 }

--- a/src/components/consumer/ProductDetailTabs.tsx
+++ b/src/components/consumer/ProductDetailTabs.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useState } from 'react';
+
+import type { ProductDetailResponse } from '@/contracts/product';
+
+type ProductDetailTabId = 'detail' | 'review' | 'store';
+
+interface ProductDetailTabsProps {
+  product: ProductDetailResponse;
+}
+
+interface ProductDetailTab {
+  id: ProductDetailTabId;
+  label: string;
+}
+
+const productDetailTabs: ProductDetailTab[] = [
+  { id: 'detail', label: '상세정보' },
+  { id: 'review', label: '리뷰' },
+  { id: 'store', label: '매장 정보' },
+];
+
+export function ProductDetailTabs({ product }: ProductDetailTabsProps) {
+  const [selectedTabId, setSelectedTabId] =
+    useState<ProductDetailTabId>('detail');
+
+  const pickupPlace = product.store.addressDetail
+    ? `${product.store.address} ${product.store.addressDetail}`
+    : product.store.address;
+
+  return (
+    <section className="mx-auto max-w-450 px-6">
+      <div className="border-b border-gray-200">
+        <nav className="flex gap-10" role="tablist" aria-label="상품 상세 정보">
+          {productDetailTabs.map((tab) => {
+            const isSelected = selectedTabId === tab.id;
+
+            return (
+              <button
+                key={tab.id}
+                id={`product-detail-tab-${tab.id}`}
+                type="button"
+                role="tab"
+                aria-selected={isSelected}
+                className={[
+                  'border-b-2 px-2 py-4 text-base font-semibold transition',
+                  isSelected
+                    ? 'border-primary-500 text-primary-500'
+                    : 'border-transparent text-gray-600 hover:text-gray-900',
+                ].join(' ')}
+                onClick={() => setSelectedTabId(tab.id)}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </nav>
+      </div>
+
+      {selectedTabId === 'detail' ? (
+        <div
+          id="product-detail-panel-detail"
+          role="tabpanel"
+          aria-labelledby="product-detail-tab-detail"
+          className="grid gap-10 py-8 lg:grid-cols-[minmax(0,1fr)_minmax(280px,660px)_minmax(0,1fr)]"
+        >
+          <div className="space-y-8">
+            <section>
+              <h2 className="mb-4 text-lg font-bold text-gray-900">
+                상품 안내
+              </h2>
+              <p className="text-sm leading-6 text-gray-700">
+                {product.description ?? '등록된 상품 설명이 없습니다.'}
+              </p>
+            </section>
+
+            <section>
+              <h2 className="mb-4 text-lg font-bold text-gray-900">
+                상품 구성
+              </h2>
+              <ul className="list-inside list-disc space-y-2 text-sm text-gray-700">
+                <li>{product.name}</li>
+              </ul>
+            </section>
+          </div>
+
+          <section className="w-full lg:col-start-2">
+            <h2 className="mb-4 text-lg font-bold text-gray-900">영양 정보</h2>
+            <div className="rounded-md border border-gray-200 bg-gray-50 px-4 py-5 text-sm text-gray-500">
+              상품별 영양 정보는 준비 중입니다.
+            </div>
+          </section>
+        </div>
+      ) : null}
+
+      {selectedTabId === 'review' ? (
+        <div
+          id="product-detail-panel-review"
+          role="tabpanel"
+          aria-labelledby="product-detail-tab-review"
+          className="py-8"
+        >
+          <div className="rounded-md border border-gray-200 bg-gray-50 p-8 text-center">
+            <h2 className="text-lg font-bold text-gray-900">리뷰</h2>
+            <p className="mt-2 text-sm text-gray-500">
+              리뷰 기능은 추후 제공 예정입니다.
+            </p>
+          </div>
+        </div>
+      ) : null}
+
+      {selectedTabId === 'store' ? (
+        <div
+          id="product-detail-panel-store"
+          role="tabpanel"
+          aria-labelledby="product-detail-tab-store"
+          className="py-8"
+        >
+          <section>
+            <dl className="grid gap-5 md:grid-cols-2">
+              <div>
+                <dt className="mb-1 text-base font-bold text-gray-900">
+                  매장명
+                </dt>
+                <dd className="text-sm text-gray-900">{product.store.name}</dd>
+              </div>
+              <div>
+                <dt className="mb-1 text-base font-bold text-gray-900">
+                  전화번호
+                </dt>
+                <dd className="text-sm text-gray-900">{product.store.phone}</dd>
+              </div>
+              <div>
+                <dt className="mb-1 text-base font-bold text-gray-900">지역</dt>
+                <dd className="text-sm text-gray-900">
+                  {product.store.region}
+                </dd>
+              </div>
+              <div>
+                <dt className="mb-1 text-base font-bold text-gray-900">주소</dt>
+                <dd className="text-sm text-gray-900">{pickupPlace}</dd>
+              </div>
+              {product.store.description ? (
+                <div className="md:col-span-2">
+                  <dt className="mb-1 text-base font-bold text-gray-900">
+                    매장 소개
+                  </dt>
+                  <dd className="text-sm text-gray-900">
+                    {product.store.description}
+                  </dd>
+                </div>
+              ) : null}
+            </dl>
+          </section>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/consumer/ProductDetailTabs.tsx
+++ b/src/components/consumer/ProductDetailTabs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState, type KeyboardEvent } from 'react';
 
 import type { ProductDetailResponse } from '@/contracts/product';
 
@@ -24,25 +24,76 @@ const productDetailTabs: ProductDetailTab[] = [
 export function ProductDetailTabs({ product }: ProductDetailTabsProps) {
   const [selectedTabId, setSelectedTabId] =
     useState<ProductDetailTabId>('detail');
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const selectedTabIndex = productDetailTabs.findIndex(
+    (tab) => tab.id === selectedTabId
+  );
 
   const pickupPlace = product.store.addressDetail
     ? `${product.store.address} ${product.store.addressDetail}`
     : product.store.address;
 
+  const selectTabByIndex = (index: number) => {
+    const nextTab = productDetailTabs[index];
+
+    if (!nextTab) {
+      return;
+    }
+
+    setSelectedTabId(nextTab.id);
+    tabRefs.current[index]?.focus();
+  };
+
+  const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    const lastTabIndex = productDetailTabs.length - 1;
+
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      selectTabByIndex(
+        selectedTabIndex === lastTabIndex ? 0 : selectedTabIndex + 1
+      );
+      return;
+    }
+
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      selectTabByIndex(
+        selectedTabIndex === 0 ? lastTabIndex : selectedTabIndex - 1
+      );
+      return;
+    }
+
+    if (event.key === 'Home') {
+      event.preventDefault();
+      selectTabByIndex(0);
+      return;
+    }
+
+    if (event.key === 'End') {
+      event.preventDefault();
+      selectTabByIndex(lastTabIndex);
+    }
+  };
+
   return (
     <section className="mx-auto max-w-450 px-6">
       <div className="border-b border-gray-200">
         <nav className="flex gap-10" role="tablist" aria-label="상품 상세 정보">
-          {productDetailTabs.map((tab) => {
+          {productDetailTabs.map((tab, index) => {
             const isSelected = selectedTabId === tab.id;
 
             return (
               <button
                 key={tab.id}
+                ref={(node) => {
+                  tabRefs.current[index] = node;
+                }}
                 id={`product-detail-tab-${tab.id}`}
                 type="button"
                 role="tab"
                 aria-selected={isSelected}
+                aria-controls={`product-detail-panel-${tab.id}`}
+                tabIndex={isSelected ? 0 : -1}
                 className={[
                   'border-b-2 px-2 py-4 text-base font-semibold transition',
                   isSelected
@@ -50,6 +101,7 @@ export function ProductDetailTabs({ product }: ProductDetailTabsProps) {
                     : 'border-transparent text-gray-600 hover:text-gray-900',
                 ].join(' ')}
                 onClick={() => setSelectedTabId(tab.id)}
+                onKeyDown={handleTabKeyDown}
               >
                 {tab.label}
               </button>
@@ -58,103 +110,95 @@ export function ProductDetailTabs({ product }: ProductDetailTabsProps) {
         </nav>
       </div>
 
-      {selectedTabId === 'detail' ? (
-        <div
-          id="product-detail-panel-detail"
-          role="tabpanel"
-          aria-labelledby="product-detail-tab-detail"
-          className="grid gap-10 py-8 lg:grid-cols-[minmax(0,1fr)_minmax(280px,660px)_minmax(0,1fr)]"
-        >
-          <div className="space-y-8">
-            <section>
-              <h2 className="mb-4 text-lg font-bold text-gray-900">
-                상품 안내
-              </h2>
-              <p className="text-sm leading-6 text-gray-700">
-                {product.description ?? '등록된 상품 설명이 없습니다.'}
-              </p>
-            </section>
+      <div
+        id="product-detail-panel-detail"
+        role="tabpanel"
+        aria-labelledby="product-detail-tab-detail"
+        tabIndex={0}
+        hidden={selectedTabId !== 'detail'}
+        className="grid gap-10 py-8 lg:grid-cols-[minmax(0,1fr)_minmax(280px,660px)_minmax(0,1fr)]"
+      >
+        <div className="space-y-8">
+          <section>
+            <h2 className="mb-4 text-lg font-bold text-gray-900">상품 안내</h2>
+            <p className="text-sm leading-6 text-gray-700">
+              {product.description ?? '등록된 상품 설명이 없습니다.'}
+            </p>
+          </section>
 
-            <section>
-              <h2 className="mb-4 text-lg font-bold text-gray-900">
-                상품 구성
-              </h2>
-              <ul className="list-inside list-disc space-y-2 text-sm text-gray-700">
-                <li>{product.name}</li>
-              </ul>
-            </section>
-          </div>
-
-          <section className="w-full lg:col-start-2">
-            <h2 className="mb-4 text-lg font-bold text-gray-900">영양 정보</h2>
-            <div className="rounded-md border border-gray-200 bg-gray-50 px-4 py-5 text-sm text-gray-500">
-              상품별 영양 정보는 준비 중입니다.
-            </div>
+          <section>
+            <h2 className="mb-4 text-lg font-bold text-gray-900">상품 구성</h2>
+            <ul className="list-inside list-disc space-y-2 text-sm text-gray-700">
+              <li>{product.name}</li>
+            </ul>
           </section>
         </div>
-      ) : null}
 
-      {selectedTabId === 'review' ? (
-        <div
-          id="product-detail-panel-review"
-          role="tabpanel"
-          aria-labelledby="product-detail-tab-review"
-          className="py-8"
-        >
-          <div className="rounded-md border border-gray-200 bg-gray-50 p-8 text-center">
-            <h2 className="text-lg font-bold text-gray-900">리뷰</h2>
-            <p className="mt-2 text-sm text-gray-500">
-              리뷰 기능은 추후 제공 예정입니다.
-            </p>
+        <section className="w-full lg:col-start-2">
+          <h2 className="mb-4 text-lg font-bold text-gray-900">영양 정보</h2>
+          <div className="rounded-md border border-gray-200 bg-gray-50 px-4 py-5 text-sm text-gray-500">
+            상품별 영양 정보는 준비 중입니다.
           </div>
-        </div>
-      ) : null}
+        </section>
+      </div>
 
-      {selectedTabId === 'store' ? (
-        <div
-          id="product-detail-panel-store"
-          role="tabpanel"
-          aria-labelledby="product-detail-tab-store"
-          className="py-8"
-        >
-          <section>
-            <dl className="grid gap-5 md:grid-cols-2">
-              <div>
+      <div
+        id="product-detail-panel-review"
+        role="tabpanel"
+        aria-labelledby="product-detail-tab-review"
+        tabIndex={0}
+        hidden={selectedTabId !== 'review'}
+        className="py-8"
+      >
+        <div className="rounded-md border border-gray-200 bg-gray-50 p-8 text-center">
+          <h2 className="text-lg font-bold text-gray-900">리뷰</h2>
+          <p className="mt-2 text-sm text-gray-500">
+            리뷰 기능은 추후 제공 예정입니다.
+          </p>
+        </div>
+      </div>
+
+      <div
+        id="product-detail-panel-store"
+        role="tabpanel"
+        aria-labelledby="product-detail-tab-store"
+        tabIndex={0}
+        hidden={selectedTabId !== 'store'}
+        className="py-8"
+      >
+        <section>
+          <dl className="grid gap-5 md:grid-cols-2">
+            <div>
+              <dt className="mb-1 text-base font-bold text-gray-900">매장명</dt>
+              <dd className="text-sm text-gray-900">{product.store.name}</dd>
+            </div>
+            <div>
+              <dt className="mb-1 text-base font-bold text-gray-900">
+                전화번호
+              </dt>
+              <dd className="text-sm text-gray-900">{product.store.phone}</dd>
+            </div>
+            <div>
+              <dt className="mb-1 text-base font-bold text-gray-900">지역</dt>
+              <dd className="text-sm text-gray-900">{product.store.region}</dd>
+            </div>
+            <div>
+              <dt className="mb-1 text-base font-bold text-gray-900">주소</dt>
+              <dd className="text-sm text-gray-900">{pickupPlace}</dd>
+            </div>
+            {product.store.description ? (
+              <div className="md:col-span-2">
                 <dt className="mb-1 text-base font-bold text-gray-900">
-                  매장명
+                  매장 소개
                 </dt>
-                <dd className="text-sm text-gray-900">{product.store.name}</dd>
-              </div>
-              <div>
-                <dt className="mb-1 text-base font-bold text-gray-900">
-                  전화번호
-                </dt>
-                <dd className="text-sm text-gray-900">{product.store.phone}</dd>
-              </div>
-              <div>
-                <dt className="mb-1 text-base font-bold text-gray-900">지역</dt>
                 <dd className="text-sm text-gray-900">
-                  {product.store.region}
+                  {product.store.description}
                 </dd>
               </div>
-              <div>
-                <dt className="mb-1 text-base font-bold text-gray-900">주소</dt>
-                <dd className="text-sm text-gray-900">{pickupPlace}</dd>
-              </div>
-              {product.store.description ? (
-                <div className="md:col-span-2">
-                  <dt className="mb-1 text-base font-bold text-gray-900">
-                    매장 소개
-                  </dt>
-                  <dd className="text-sm text-gray-900">
-                    {product.store.description}
-                  </dd>
-                </div>
-              ) : null}
-            </dl>
-          </section>
-        </div>
-      ) : null}
+            ) : null}
+          </dl>
+        </section>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## 📌 작업 내용

- 상품 상세 페이지 하단 정보 탭 영역을 컴포넌트로 분리했습니다.
- 상세정보, 리뷰, 매장 정보 탭 전환 기능을 구현했습니다.
- 현재 API/mock 데이터 기준으로 표시 가능한 상품/매장 정보를 렌더링했습니다.
- API 데이터가 없는 영양 정보와 리뷰 영역은 준비 중 상태로 표시했습니다.

## 🔧 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 📂 주요 변경 파일

- `src/components/consumer/ProductDetailTabs.tsx`
- `src/app/(consumer)/products/[productId]/page.tsx`

## 🧪 테스트 방법

- `/products/product_1` 상세 페이지 접속
- 상세정보 탭에서 상품 안내, 상품 구성, 영양 정보 준비 중 문구 확인
- 리뷰 탭 클릭 시 리뷰 준비 중 문구 확인
- 매장 정보 탭 클릭 시 매장명, 전화번호, 지역, 주소, 매장 소개 확인
- 탭 선택 시 선택 스타일이 변경되는지 확인
- `npm run lint`

## 📸 스크린샷 (선택)

- 상품 상세 페이지 하단 정보 탭 캡처 첨부

## 🔗 관련 이슈

- close #53

## 📝 참고

- 현재 상품 상세 API에는 리뷰/영양 정보 데이터가 없어 실제 수치나 리뷰 목록은 렌더링하지 않았습니다.
- 영양 정보와 리뷰는 추후 API 연동 시 확장할 수 있도록 준비 중 상태로 처리했습니다.
- 상세정보 탭에서는 예약/픽업 안내를 제외하고 상품 안내, 상품 구성, 영양 정보 중심으로 구성했습니다.
