### PR TITLE
feat: 소비자 공통 헤더 컴포넌트 구현

### DIFF
--- a/src/app/(consumer)/page.tsx
+++ b/src/app/(consumer)/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { LogInIcon, StoreIcon } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
@@ -12,7 +11,8 @@ import {
   ALL_CATEGORY_ID,
   getConsumerProductCategories,
 } from '@/hooks/products/useConsumerProducts';
-import { Footer, Header } from '@/components/common';
+import { Footer } from '@/components/common';
+import { ConsumerHeader } from '@/components/consumer/ConsumerHeader';
 import { ConsumerHeaderSearch } from '@/components/consumer/ConsumerHeaderSearch';
 import { ConsumerProductList } from '@/components/consumer/ConsumerProductList';
 import { ProductFilterSidebar } from '@/components/consumer/ProductFilterSidebar';
@@ -129,9 +129,7 @@ export default function ConsumerPage() {
 
   return (
     <div className="bg-white">
-      <Header
-        user={null}
-        logoHref="/"
+      <ConsumerHeader
         slot={
           <ConsumerHeaderSearch
             regionItems={regionItems}
@@ -142,22 +140,6 @@ export default function ConsumerPage() {
             onSearch={handleSearch}
           />
         }
-        menuItems={[
-          {
-            label: '판매자센터',
-            type: 'link',
-            href: '/seller',
-            icon: <StoreIcon className="h-5 w-5" aria-hidden="true" />,
-            className: 'whitespace-nowrap',
-          },
-          {
-            label: '로그인',
-            type: 'link',
-            href: '/login',
-            icon: <LogInIcon className="h-5 w-5" aria-hidden="true" />,
-            className: 'whitespace-nowrap',
-          },
-        ]}
       />
 
       <main className="min-h-screen bg-white">

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -115,7 +115,7 @@ function UserMenu({
           <ChevronDownIcon className="h-4 w-4 group-data-active:hidden" />
           <ChevronUpIcon className="hidden h-4 w-4 group-data-active:block" />
         </MenuButton>
-        <MenuItems className="absolute right-0 mt-2 w-48 rounded border border-gray-200 bg-white shadow-lg focus:outline-none">
+        <MenuItems className="absolute right-0 z-50 mt-2 w-48 rounded border border-gray-200 bg-white shadow-lg focus:outline-none">
           {menuItems.map((item) =>
             item.type === 'link' ? (
               <MenuItem

--- a/src/components/consumer/ConsumerHeader.tsx
+++ b/src/components/consumer/ConsumerHeader.tsx
@@ -3,6 +3,7 @@
 import { Store, User } from 'lucide-react';
 import type { ReactNode } from 'react';
 
+import { useMe } from '@/hooks/users/useMe';
 import { useAuthModal } from '@/components/auth/useAuthModal';
 import { Header } from '@/components/common';
 
@@ -12,26 +13,42 @@ interface ConsumerHeaderProps {
 
 export function ConsumerHeader({ slot }: ConsumerHeaderProps) {
   const { openAuthModal } = useAuthModal();
+  const { data: user = null } = useMe();
+
+  const guestMenuItems = [
+    {
+      label: '판매자센터',
+      type: 'link' as const,
+      href: '/seller',
+      icon: <Store className="size-5" aria-hidden="true" />,
+    },
+    {
+      label: '로그인',
+      type: 'action' as const,
+      onClick: () => openAuthModal('login'),
+      icon: <User className="size-5" aria-hidden="true" />,
+    },
+  ];
+
+  const userMenuItems = [
+    {
+      label: '판매자센터',
+      type: 'link' as const,
+      href: '/seller',
+    },
+    {
+      label: '마이페이지',
+      type: 'link' as const,
+      href: '/mypage',
+    },
+  ];
 
   return (
     <Header
-      user={null}
+      user={user}
       logoHref="/"
       slot={slot}
-      menuItems={[
-        {
-          label: '판매자센터',
-          type: 'link',
-          href: '/seller',
-          icon: <Store className="size-5" aria-hidden="true" />,
-        },
-        {
-          label: '로그인',
-          type: 'action',
-          onClick: () => openAuthModal('login'),
-          icon: <User className="size-5" aria-hidden="true" />,
-        },
-      ]}
+      menuItems={user ? userMenuItems : guestMenuItems}
     />
   );
 }

--- a/src/components/consumer/ConsumerHeader.tsx
+++ b/src/components/consumer/ConsumerHeader.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { Store, User } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+import { useAuthModal } from '@/components/auth/useAuthModal';
+import { Header } from '@/components/common';
+
+interface ConsumerHeaderProps {
+  slot?: ReactNode;
+}
+
+export function ConsumerHeader({ slot }: ConsumerHeaderProps) {
+  const { openAuthModal } = useAuthModal();
+
+  return (
+    <Header
+      user={null}
+      logoHref="/"
+      slot={slot}
+      menuItems={[
+        {
+          label: '판매자센터',
+          type: 'link',
+          href: '/seller',
+          icon: <Store className="size-5" aria-hidden="true" />,
+        },
+        {
+          label: '로그인',
+          type: 'action',
+          onClick: () => openAuthModal('login'),
+          icon: <User className="size-5" aria-hidden="true" />,
+        },
+      ]}
+    />
+  );
+}


### PR DESCRIPTION
## 📌 작업 내용

- 소비자 페이지에서 공통으로 사용할 `ConsumerHeader` 컴포넌트를 추가했습니다.
- 기존 메인 페이지의 공통 `Header` 직접 사용을 `ConsumerHeader`로 교체했습니다.
- 로그인 버튼 클릭 시 `/login` 페이지 이동 대신 전역 로그인 모달이 열리도록 연결했습니다.
- 기존 검색/지역 선택 영역은 `slot`으로 전달해 유지했습니다.

## 🔧 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 📂 주요 변경 파일

- `src/components/consumer/ConsumerHeader.tsx`
- `src/app/(consumer)/page.tsx`

## 🧪 테스트 방법

- `/` 메인 페이지 접속
- 헤더에 판매자센터/로그인 메뉴가 표시되는지 확인
- 로그인 버튼 클릭 시 로그인 모달이 열리는지 확인
- 검색창과 지역 선택 영역이 기존처럼 렌더링되는지 확인
- `npm run lint`

## 📸 스크린샷 (선택)

- X

## 🔗 관련 이슈

- close #58 

## 📝 참고

- `ConsumerHeader`는 공통 `Header`를 감싸는 소비자 페이지 전용 wrapper입니다.
- 검색/지역 영역은 `slot`으로 주입할 수 있도록 구성했습니다.
- 상세 페이지 등 다른 소비자 페이지에는 관련 PR 머지 상황에 맞춰 이후 적용할 예정입니다.
