### PR TITLE
가게 등록 API 구현

### DIFF
--- a/docs/api_spec.md
+++ b/docs/api_spec.md
@@ -512,6 +512,7 @@ Behavior:
 
 - 로그인 사용자가 이미 가게를 가지고 있으면 실패한다.
 - 생성된 가게 status는 승인 대기 상태이다.
+- DB unique 충돌(`user_id` 중복, `business_number` 중복 모두 포함)은 `STORE_ALREADY_EXISTS (409)`로 반환한다.
 
 DB source:
 

--- a/src/app/api/stores/_lib/mapper.test.ts
+++ b/src/app/api/stores/_lib/mapper.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Database } from '@/lib/supabase/database';
+
+import { mapStoreRow } from './mapper';
+
+type StoresRow = Database['public']['Tables']['stores']['Row'];
+
+const baseRow: StoresRow = {
+  id: 'store-1',
+  user_id: 'user-1',
+  name: '픽마 베이커리',
+  description: null,
+  business_number: '123-45-67890',
+  phone: '02-1234-5678',
+  address: '서울시 마포구 월드컵북로 12',
+  address_detail: null,
+  region: '서울 마포구',
+  image: null,
+  open_time: null,
+  close_time: null,
+  status: 'pending',
+  reject_reason: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+describe('mapStoreRow', () => {
+  it('DB row를 StoreResponse DTO로 변환한다', () => {
+    expect(mapStoreRow(baseRow)).toEqual({
+      id: 'store-1',
+      userId: 'user-1',
+      name: '픽마 베이커리',
+      description: undefined,
+      businessNumber: '123-45-67890',
+      phone: '02-1234-5678',
+      address: '서울시 마포구 월드컵북로 12',
+      addressDetail: undefined,
+      region: '서울 마포구',
+      image: undefined,
+      openTime: undefined,
+      closeTime: undefined,
+      status: 'pending',
+      rejectReason: undefined,
+      canSell: false,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+  });
+
+  it('null 필드를 undefined로 변환한다', () => {
+    const result = mapStoreRow(baseRow);
+    expect(result.description).toBeUndefined();
+    expect(result.addressDetail).toBeUndefined();
+    expect(result.image).toBeUndefined();
+    expect(result.openTime).toBeUndefined();
+    expect(result.closeTime).toBeUndefined();
+    expect(result.rejectReason).toBeUndefined();
+  });
+
+  it('null이 아닌 선택 필드는 그대로 반환한다', () => {
+    const result = mapStoreRow({
+      ...baseRow,
+      description: '매일 아침 굽는 동네 베이커리입니다.',
+      address_detail: '1층',
+      image: 'https://example.com/store.jpg',
+      open_time: '09:00:00',
+      close_time: '21:00:00',
+      reject_reason: '서류 미비',
+    });
+    expect(result.description).toBe('매일 아침 굽는 동네 베이커리입니다.');
+    expect(result.addressDetail).toBe('1층');
+    expect(result.image).toBe('https://example.com/store.jpg');
+    expect(result.openTime).toBe('09:00:00');
+    expect(result.closeTime).toBe('21:00:00');
+    expect(result.rejectReason).toBe('서류 미비');
+  });
+
+  it('canSell은 항상 false다', () => {
+    expect(mapStoreRow(baseRow).canSell).toBe(false);
+    expect(mapStoreRow({ ...baseRow, status: 'approved' }).canSell).toBe(false);
+  });
+});

--- a/src/app/api/stores/_lib/mapper.ts
+++ b/src/app/api/stores/_lib/mapper.ts
@@ -1,0 +1,26 @@
+import type { StoreResponse } from '@/contracts/store';
+import type { Database } from '@/lib/supabase/database';
+
+type StoresRow = Database['public']['Tables']['stores']['Row'];
+
+export function mapStoreRow(row: StoresRow): StoreResponse {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    name: row.name,
+    description: row.description ?? undefined,
+    businessNumber: row.business_number,
+    phone: row.phone,
+    address: row.address,
+    addressDetail: row.address_detail ?? undefined,
+    region: row.region,
+    image: row.image ?? undefined,
+    openTime: row.open_time ?? undefined,
+    closeTime: row.close_time ?? undefined,
+    status: row.status,
+    rejectReason: row.reject_reason ?? undefined,
+    canSell: false,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}

--- a/src/app/api/stores/_lib/service.test.ts
+++ b/src/app/api/stores/_lib/service.test.ts
@@ -169,10 +169,24 @@ describe('createStore', () => {
     expect(insertPayload.close_time).toBe('21:30:00');
   });
 
-  it('INSERT DB 오류 시 INTERNAL_SERVER_ERROR를 던진다', async () => {
+  it('INSERT unique 충돌(23505) 시 STORE_ALREADY_EXISTS를 던진다', async () => {
     const { client } = makeServiceClient(
       { data: null, error: null },
       { data: null, error: { code: '23505' } }
+    );
+    vi.mocked(createServiceRoleClient).mockReturnValue(
+      client as unknown as ReturnType<typeof createServiceRoleClient>
+    );
+    await expect(createStore('user-1', mockBody)).rejects.toMatchObject({
+      code: 'STORE_ALREADY_EXISTS',
+      statusCode: 409,
+    });
+  });
+
+  it('INSERT 기타 DB 오류 시 INTERNAL_SERVER_ERROR를 던진다', async () => {
+    const { client } = makeServiceClient(
+      { data: null, error: null },
+      { data: null, error: { code: '42501' } }
     );
     vi.mocked(createServiceRoleClient).mockReturnValue(
       client as unknown as ReturnType<typeof createServiceRoleClient>

--- a/src/app/api/stores/_lib/service.test.ts
+++ b/src/app/api/stores/_lib/service.test.ts
@@ -80,6 +80,7 @@ function makeServiceClient(
           }),
         };
       }
+      throw new Error(`Unexpected table in test stub: ${table}`);
     }),
   };
 

--- a/src/app/api/stores/_lib/service.test.ts
+++ b/src/app/api/stores/_lib/service.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createServiceRoleClient } from '@/lib/supabase/service';
+import { mapStoreRow } from '@/app/api/stores/_lib/mapper';
+
+import { createStore } from './service';
+
+vi.mock('@/lib/supabase/service');
+vi.mock('@/app/api/stores/_lib/mapper');
+
+const mockBody = {
+  name: '픽마 베이커리',
+  businessNumber: '123-45-67890',
+  phone: '02-1234-5678',
+  address: '서울시 마포구 월드컵북로 12',
+  region: '서울 마포구',
+};
+
+const mockRow = {
+  id: 'store-1',
+  user_id: 'user-1',
+  name: '픽마 베이커리',
+  description: null,
+  business_number: '123-45-67890',
+  phone: '02-1234-5678',
+  address: '서울시 마포구 월드컵북로 12',
+  address_detail: null,
+  region: '서울 마포구',
+  image: null,
+  open_time: null,
+  close_time: null,
+  status: 'pending' as const,
+  reject_reason: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const mockStoreResponse = {
+  id: 'store-1',
+  userId: 'user-1',
+  name: '픽마 베이커리',
+  businessNumber: '123-45-67890',
+  phone: '02-1234-5678',
+  address: '서울시 마포구 월드컵북로 12',
+  region: '서울 마포구',
+  status: 'pending' as const,
+  canSell: false,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+type CheckResult = {
+  data: { id: string } | null;
+  error: { code: string } | null;
+};
+type InsertResult = {
+  data: typeof mockRow | null;
+  error: { code: string } | null;
+};
+
+function makeServiceClient(
+  checkResult: CheckResult,
+  insertResult: InsertResult
+) {
+  const insertFn = vi.fn();
+
+  const client = {
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'stores') {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: () => Promise.resolve(checkResult),
+            }),
+          }),
+          insert: insertFn.mockReturnValue({
+            select: () => ({
+              single: () => Promise.resolve(insertResult),
+            }),
+          }),
+        };
+      }
+    }),
+  };
+
+  return { client, insertFn };
+}
+
+describe('createStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(mapStoreRow).mockReturnValue(mockStoreResponse);
+  });
+
+  it('이미 가게가 있으면 STORE_ALREADY_EXISTS를 던진다', async () => {
+    const { client } = makeServiceClient(
+      { data: { id: 'store-existing' }, error: null },
+      { data: null, error: null }
+    );
+    vi.mocked(createServiceRoleClient).mockReturnValue(
+      client as unknown as ReturnType<typeof createServiceRoleClient>
+    );
+    await expect(createStore('user-1', mockBody)).rejects.toMatchObject({
+      code: 'STORE_ALREADY_EXISTS',
+      statusCode: 409,
+    });
+  });
+
+  it('중복 확인 DB 오류 시 INTERNAL_SERVER_ERROR를 던진다', async () => {
+    const { client } = makeServiceClient(
+      { data: null, error: { code: '42501' } },
+      { data: null, error: null }
+    );
+    vi.mocked(createServiceRoleClient).mockReturnValue(
+      client as unknown as ReturnType<typeof createServiceRoleClient>
+    );
+    await expect(createStore('user-1', mockBody)).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      statusCode: 500,
+    });
+  });
+
+  it('정상 생성 시 INSERT payload에 status/created_at/updated_at이 없고 mapStoreRow 결과를 반환한다', async () => {
+    const { client, insertFn } = makeServiceClient(
+      { data: null, error: null },
+      { data: mockRow, error: null }
+    );
+    vi.mocked(createServiceRoleClient).mockReturnValue(
+      client as unknown as ReturnType<typeof createServiceRoleClient>
+    );
+    const result = await createStore('user-1', mockBody);
+    const insertPayload = insertFn.mock.calls[0][0];
+    expect(insertPayload).not.toHaveProperty('status');
+    expect(insertPayload).not.toHaveProperty('created_at');
+    expect(insertPayload).not.toHaveProperty('updated_at');
+    expect(mapStoreRow).toHaveBeenCalledWith(mockRow);
+    expect(result).toBe(mockStoreResponse);
+  });
+
+  it('openTime/closeTime 없으면 null로 INSERT한다', async () => {
+    const { client, insertFn } = makeServiceClient(
+      { data: null, error: null },
+      { data: mockRow, error: null }
+    );
+    vi.mocked(createServiceRoleClient).mockReturnValue(
+      client as unknown as ReturnType<typeof createServiceRoleClient>
+    );
+    await createStore('user-1', mockBody);
+    const insertPayload = insertFn.mock.calls[0][0];
+    expect(insertPayload.open_time).toBeNull();
+    expect(insertPayload.close_time).toBeNull();
+  });
+
+  it('openTime/closeTime 있으면 앞 8자만 INSERT한다', async () => {
+    const { client, insertFn } = makeServiceClient(
+      { data: null, error: null },
+      { data: mockRow, error: null }
+    );
+    vi.mocked(createServiceRoleClient).mockReturnValue(
+      client as unknown as ReturnType<typeof createServiceRoleClient>
+    );
+    await createStore('user-1', {
+      ...mockBody,
+      openTime: '09:00:00.000',
+      closeTime: '21:30:00.000',
+    });
+    const insertPayload = insertFn.mock.calls[0][0];
+    expect(insertPayload.open_time).toBe('09:00:00');
+    expect(insertPayload.close_time).toBe('21:30:00');
+  });
+
+  it('INSERT DB 오류 시 INTERNAL_SERVER_ERROR를 던진다', async () => {
+    const { client } = makeServiceClient(
+      { data: null, error: null },
+      { data: null, error: { code: '23505' } }
+    );
+    vi.mocked(createServiceRoleClient).mockReturnValue(
+      client as unknown as ReturnType<typeof createServiceRoleClient>
+    );
+    await expect(createStore('user-1', mockBody)).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      statusCode: 500,
+    });
+  });
+});

--- a/src/app/api/stores/_lib/service.ts
+++ b/src/app/api/stores/_lib/service.ts
@@ -38,8 +38,13 @@ export async function createStore(
     .select('*')
     .single();
 
-  if (insertError || !row)
+  if (insertError) {
+    if (insertError.code === '23505') {
+      throw new AppError(ERROR_CODE.STORE_ALREADY_EXISTS, 409);
+    }
     throw new AppError(ERROR_CODE.INTERNAL_SERVER_ERROR, 500);
+  }
+  if (!row) throw new AppError(ERROR_CODE.INTERNAL_SERVER_ERROR, 500);
 
   return mapStoreRow(row);
 }

--- a/src/app/api/stores/_lib/service.ts
+++ b/src/app/api/stores/_lib/service.ts
@@ -1,0 +1,45 @@
+import type { StoreResponse, CreateStoreRequest } from '@/contracts/store';
+import { AppError } from '@/lib/errors/appError';
+import { ERROR_CODE } from '@/lib/errors/errorCodes';
+import { createServiceRoleClient } from '@/lib/supabase/service';
+
+import { mapStoreRow } from './mapper';
+
+export async function createStore(
+  userId: string,
+  body: CreateStoreRequest
+): Promise<StoreResponse> {
+  const supabase = createServiceRoleClient();
+
+  const { data: existing, error: checkError } = await supabase
+    .from('stores')
+    .select('id')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (checkError) throw new AppError(ERROR_CODE.INTERNAL_SERVER_ERROR, 500);
+  if (existing) throw new AppError(ERROR_CODE.STORE_ALREADY_EXISTS, 409);
+
+  const { data: row, error: insertError } = await supabase
+    .from('stores')
+    .insert({
+      user_id: userId,
+      name: body.name,
+      description: body.description ?? null,
+      business_number: body.businessNumber,
+      phone: body.phone,
+      address: body.address,
+      address_detail: body.addressDetail ?? null,
+      region: body.region,
+      image: body.image ?? null,
+      open_time: body.openTime ? body.openTime.slice(0, 8) : null,
+      close_time: body.closeTime ? body.closeTime.slice(0, 8) : null,
+    })
+    .select('*')
+    .single();
+
+  if (insertError || !row)
+    throw new AppError(ERROR_CODE.INTERNAL_SERVER_ERROR, 500);
+
+  return mapStoreRow(row);
+}

--- a/src/app/api/stores/route.ts
+++ b/src/app/api/stores/route.ts
@@ -1,21 +1,25 @@
 import type { NextRequest } from 'next/server';
 
-import { ERROR_CODE } from '@/lib/errors/errorCodes';
+import { requireActiveUser } from '@/app/api/_lib/auth';
 import { isApiMockEnabled } from '@/app/api/_lib/mock';
-import { fail, routeError, success } from '@/app/api/_lib/response';
+import { routeError, success } from '@/app/api/_lib/response';
 import { validateBody } from '@/app/api/_lib/validation';
 import { mockPendingStore } from '@/mocks/stores';
 
 import { createStoreSchema } from './_lib/schemas';
+import { createStore } from './_lib/service';
 
 export async function POST(request: NextRequest): Promise<Response> {
-  if (!isApiMockEnabled()) {
-    return fail(ERROR_CODE.NOT_IMPLEMENTED);
-  }
-
   try {
-    await validateBody(createStoreSchema, request);
-    return success(mockPendingStore, 201);
+    if (isApiMockEnabled()) {
+      await validateBody(createStoreSchema, request);
+      return success(mockPendingStore, 201);
+    }
+
+    const { serviceUser } = await requireActiveUser();
+    const body = await validateBody(createStoreSchema, request);
+    const store = await createStore(serviceUser.id, body);
+    return success(store, 201);
   } catch (error) {
     return routeError(error);
   }

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -28,13 +28,29 @@ INSERT INTO auth.users (
    'authenticated', 'authenticated',
    'seller2@pickma-seed.local', '',
    now(), '{"provider":"email","providers":["email"]}', '{}',
+   now(), now()),
+  -- seller3: pending 가게 등록 상태 시뮬레이션
+  ('00000000-0000-4000-8000-000000000023',
+   '00000000-0000-4000-8000-000000000000',
+   'authenticated', 'authenticated',
+   'seller3@pickma-seed.local', '',
+   now(), '{"provider":"email","providers":["email"]}', '{}',
+   now(), now()),
+  -- customer1: 가게 미등록 사용자 (POST /api/stores 테스트용)
+  ('00000000-0000-4000-8000-000000000024',
+   '00000000-0000-4000-8000-000000000000',
+   'authenticated', 'authenticated',
+   'customer1@pickma-seed.local', '',
+   now(), '{"provider":"email","providers":["email"]}', '{}',
    now(), now());
 
 INSERT INTO public.users (id, email, name, role, status) VALUES
   ('00000000-0000-4000-8000-000000000021', 'seller1@pickma-seed.local', '씨드 판매자1', 'seller', 'active'),
-  ('00000000-0000-4000-8000-000000000022', 'seller2@pickma-seed.local', '씨드 판매자2', 'seller', 'active');
+  ('00000000-0000-4000-8000-000000000022', 'seller2@pickma-seed.local', '씨드 판매자2', 'seller', 'active'),
+  ('00000000-0000-4000-8000-000000000023', 'seller3@pickma-seed.local', '씨드 판매자3', 'seller', 'active'),
+  ('00000000-0000-4000-8000-000000000024', 'customer1@pickma-seed.local', '씨드 고객1', 'customer', 'active');
 
--- Stores: 1 approved, 1 inactive (RLS 검증용)
+-- Stores: 1 approved, 1 inactive, 1 pending (RLS 및 가게 등록 흐름 검증용)
 INSERT INTO public.stores (id, user_id, name, description, business_number, phone, address, address_detail, region, status) VALUES
   ('00000000-0000-4000-8000-000000000031',
    '00000000-0000-4000-8000-000000000021',
@@ -47,7 +63,14 @@ INSERT INTO public.stores (id, user_id, name, description, business_number, phon
    '비활성 카페', '비활성 상태의 테스트 카페입니다.',
    '0987654321', '02-9876-5432',
    '서울시 서초구 강남대로 100', NULL,
-   '서울 서초구', 'inactive');
+   '서울 서초구', 'inactive'),
+  -- pending: 가게 등록 신청 직후 상태 시뮬레이션
+  ('00000000-0000-4000-8000-000000000033',
+   '00000000-0000-4000-8000-000000000023',
+   '씨드 델리', '등록 심사 중인 가게입니다.',
+   '1111111111', '02-1111-2222',
+   '서울시 강남구 테헤란로 50', NULL,
+   '서울 강남구', 'pending');
 
 -- Menu items
 INSERT INTO public.menu_items (id, store_id, category_id, name, description, original_price) VALUES

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -11,7 +11,9 @@ INSERT INTO public.categories (id, name, icon, sort_order) VALUES
   ('00000000-0000-4000-8000-000000000014', '샐러드',    'salad',  4),
   ('00000000-0000-4000-8000-000000000015', '분식',      'food',   5);
 
--- Store owner accounts
+-- Seed accounts (local/dev only)
+-- encrypted_password is intentionally empty: these accounts exist for DB state simulation,
+-- not UI login. Use a real sign-up account for manual API verification (POST /api/stores etc.).
 INSERT INTO auth.users (
   id, instance_id, aud, role, email, encrypted_password,
   email_confirmed_at, raw_app_meta_data, raw_user_meta_data,


### PR DESCRIPTION
## 📌 작업 내용

- `POST /api/stores` 및 관련된 헬퍼와 테스트를 구현했습니다.

## 🔧 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서 수정

## 📂 주요 변경 파일

- `src/app/api/stores/route.ts`

## 🧪 테스트 방법

- 테스트용 페이지 임시 구현 후 `npm run dev`로 직접 테스트

## 🔗 관련 이슈

- closes #56 
