### PR TITLE
가게 상태 조회 API 구현

### DIFF
--- a/src/api/stores/storeApi.test.ts
+++ b/src/api/stores/storeApi.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MyStore } from '@/types/store';
+import type { StoreResponse } from '@/contracts/store';
+
+import { ApiError, apiClient } from '../apiClient';
+import { storeApi } from './storeApi';
+import { mapMyStore } from './storeMapper';
+
+vi.mock('../apiClient', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    apiClient: {
+      get: vi.fn(),
+      post: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    },
+  };
+});
+
+vi.mock('./storeMapper', () => ({
+  mapMyStore: vi.fn(),
+}));
+
+const mockStoreResponse: StoreResponse = {
+  id: 'store-1',
+  userId: 'user-1',
+  name: '픽마 베이커리',
+  businessNumber: '123-45-67890',
+  phone: '02-1234-5678',
+  address: '서울시 마포구 월드컵북로 12',
+  region: '서울 마포구',
+  status: 'approved',
+  canSell: true,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+const mockMyStore: MyStore = {
+  id: 'store-1',
+  userId: 'user-1',
+  name: '픽마 베이커리',
+  businessNumber: '123-45-67890',
+  phone: '02-1234-5678',
+  address: '서울시 마포구 월드컵북로 12',
+  region: '서울 마포구',
+  status: 'approved',
+  canSell: true,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+};
+
+describe('storeApi.getMyStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(mapMyStore).mockReturnValue(mockMyStore);
+  });
+
+  it('정상 응답은 mapMyStore 결과를 반환한다', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(mockStoreResponse);
+    const result = await storeApi.getMyStore();
+    expect(mapMyStore).toHaveBeenCalledWith(mockStoreResponse);
+    expect(result).toBe(mockMyStore);
+  });
+
+  it('STORE_NOT_FOUND ApiError는 null을 반환한다', async () => {
+    vi.mocked(apiClient.get).mockRejectedValue(
+      new ApiError(404, 'STORE_NOT_FOUND', '가게를 찾을 수 없습니다.')
+    );
+    const result = await storeApi.getMyStore();
+    expect(result).toBeNull();
+  });
+
+  it('다른 ApiError는 rethrow한다', async () => {
+    const error = new ApiError(401, 'UNAUTHORIZED', '인증이 필요합니다.');
+    vi.mocked(apiClient.get).mockRejectedValue(error);
+    await expect(storeApi.getMyStore()).rejects.toBe(error);
+  });
+});

--- a/src/api/stores/storeApi.ts
+++ b/src/api/stores/storeApi.ts
@@ -1,7 +1,7 @@
 import type { MyStore } from '@/types/store';
 import type { CreateStoreRequest, StoreResponse } from '@/contracts/store';
 
-import { apiClient } from '../apiClient';
+import { ApiError, apiClient } from '../apiClient';
 import { mapMyStore } from './storeMapper';
 
 export const storeApi = {
@@ -9,7 +9,16 @@ export const storeApi = {
     return apiClient.post<StoreResponse>('/api/stores', body).then(mapMyStore);
   },
 
-  getMyStore(): Promise<MyStore> {
-    return apiClient.get<StoreResponse>('/api/stores/me').then(mapMyStore);
+  async getMyStore(): Promise<MyStore | null> {
+    try {
+      return await apiClient
+        .get<StoreResponse>('/api/stores/me')
+        .then(mapMyStore);
+    } catch (error) {
+      if (error instanceof ApiError && error.code === 'STORE_NOT_FOUND') {
+        return null;
+      }
+      throw error;
+    }
   },
 };

--- a/src/app/api/stores/_lib/mapper.test.ts
+++ b/src/app/api/stores/_lib/mapper.test.ts
@@ -27,7 +27,7 @@ const baseRow: StoresRow = {
 
 describe('mapStoreRow', () => {
   it('DB row를 StoreResponse DTO로 변환한다', () => {
-    expect(mapStoreRow(baseRow)).toEqual({
+    expect(mapStoreRow(baseRow, false)).toEqual({
       id: 'store-1',
       userId: 'user-1',
       name: '픽마 베이커리',
@@ -49,7 +49,7 @@ describe('mapStoreRow', () => {
   });
 
   it('null 필드를 undefined로 변환한다', () => {
-    const result = mapStoreRow(baseRow);
+    const result = mapStoreRow(baseRow, false);
     expect(result.description).toBeUndefined();
     expect(result.addressDetail).toBeUndefined();
     expect(result.image).toBeUndefined();
@@ -59,15 +59,18 @@ describe('mapStoreRow', () => {
   });
 
   it('null이 아닌 선택 필드는 그대로 반환한다', () => {
-    const result = mapStoreRow({
-      ...baseRow,
-      description: '매일 아침 굽는 동네 베이커리입니다.',
-      address_detail: '1층',
-      image: 'https://example.com/store.jpg',
-      open_time: '09:00:00',
-      close_time: '21:00:00',
-      reject_reason: '서류 미비',
-    });
+    const result = mapStoreRow(
+      {
+        ...baseRow,
+        description: '매일 아침 굽는 동네 베이커리입니다.',
+        address_detail: '1층',
+        image: 'https://example.com/store.jpg',
+        open_time: '09:00:00',
+        close_time: '21:00:00',
+        reject_reason: '서류 미비',
+      },
+      false
+    );
     expect(result.description).toBe('매일 아침 굽는 동네 베이커리입니다.');
     expect(result.addressDetail).toBe('1층');
     expect(result.image).toBe('https://example.com/store.jpg');
@@ -76,8 +79,11 @@ describe('mapStoreRow', () => {
     expect(result.rejectReason).toBe('서류 미비');
   });
 
-  it('canSell은 항상 false다', () => {
-    expect(mapStoreRow(baseRow).canSell).toBe(false);
-    expect(mapStoreRow({ ...baseRow, status: 'approved' }).canSell).toBe(false);
+  it('canSell 파라미터를 DTO에 그대로 반영한다', () => {
+    expect(mapStoreRow(baseRow, false).canSell).toBe(false);
+    expect(mapStoreRow(baseRow, true).canSell).toBe(true);
+    expect(mapStoreRow({ ...baseRow, status: 'approved' }, true).canSell).toBe(
+      true
+    );
   });
 });

--- a/src/app/api/stores/_lib/mapper.ts
+++ b/src/app/api/stores/_lib/mapper.ts
@@ -3,7 +3,7 @@ import type { Database } from '@/lib/supabase/database';
 
 type StoresRow = Database['public']['Tables']['stores']['Row'];
 
-export function mapStoreRow(row: StoresRow): StoreResponse {
+export function mapStoreRow(row: StoresRow, canSell: boolean): StoreResponse {
   return {
     id: row.id,
     userId: row.user_id,
@@ -19,7 +19,7 @@ export function mapStoreRow(row: StoresRow): StoreResponse {
     closeTime: row.close_time ?? undefined,
     status: row.status,
     rejectReason: row.reject_reason ?? undefined,
-    canSell: false,
+    canSell,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/src/app/api/stores/_lib/service.test.ts
+++ b/src/app/api/stores/_lib/service.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { createServerClient } from '@/lib/supabase/server';
 import { createServiceRoleClient } from '@/lib/supabase/service';
 import { mapStoreRow } from '@/app/api/stores/_lib/mapper';
 
-import { createStore } from './service';
+import { createStore, getMyStore } from './service';
 
+vi.mock('@/lib/supabase/server');
 vi.mock('@/lib/supabase/service');
 vi.mock('@/app/api/stores/_lib/mapper');
 
@@ -196,5 +198,103 @@ describe('createStore', () => {
       code: 'INTERNAL_SERVER_ERROR',
       statusCode: 500,
     });
+  });
+});
+
+type ServerClientRow = Omit<typeof mockRow, 'status'> & {
+  status: 'pending' | 'approved' | 'rejected' | 'inactive';
+};
+
+function makeServerClient(result: {
+  data: ServerClientRow | null;
+  error: { code: string } | null;
+}) {
+  return {
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'stores') {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: () => Promise.resolve(result),
+            }),
+          }),
+        };
+      }
+      throw new Error(`Unexpected table in test stub: ${table}`);
+    }),
+  };
+}
+
+describe('getMyStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(mapStoreRow).mockReturnValue(mockStoreResponse);
+  });
+
+  it('가게가 없으면 STORE_NOT_FOUND를 던진다', async () => {
+    vi.mocked(createServerClient).mockResolvedValue(
+      makeServerClient({ data: null, error: null }) as unknown as Awaited<
+        ReturnType<typeof createServerClient>
+      >
+    );
+    await expect(getMyStore('user-1', 'customer')).rejects.toMatchObject({
+      code: 'STORE_NOT_FOUND',
+      statusCode: 404,
+    });
+  });
+
+  it('DB 오류 시 INTERNAL_SERVER_ERROR를 던진다', async () => {
+    vi.mocked(createServerClient).mockResolvedValue(
+      makeServerClient({
+        data: null,
+        error: { code: '42501' },
+      }) as unknown as Awaited<ReturnType<typeof createServerClient>>
+    );
+    await expect(getMyStore('user-1', 'customer')).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      statusCode: 500,
+    });
+  });
+
+  it('role=seller, status=approved이면 mapStoreRow(row, true)를 호출한다', async () => {
+    vi.mocked(createServerClient).mockResolvedValue(
+      makeServerClient({
+        data: { ...mockRow, status: 'approved' as const },
+        error: null,
+      }) as unknown as Awaited<ReturnType<typeof createServerClient>>
+    );
+    await getMyStore('user-1', 'seller');
+    expect(mapStoreRow).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'approved' }),
+      true
+    );
+  });
+
+  it('role=customer이면 mapStoreRow(row, false)를 호출한다', async () => {
+    vi.mocked(createServerClient).mockResolvedValue(
+      makeServerClient({
+        data: { ...mockRow, status: 'approved' as const },
+        error: null,
+      }) as unknown as Awaited<ReturnType<typeof createServerClient>>
+    );
+    await getMyStore('user-1', 'customer');
+    expect(mapStoreRow).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'approved' }),
+      false
+    );
+  });
+
+  it('role=seller, status=pending이면 mapStoreRow(row, false)를 호출한다', async () => {
+    vi.mocked(createServerClient).mockResolvedValue(
+      makeServerClient({
+        data: { ...mockRow, status: 'pending' as const },
+        error: null,
+      }) as unknown as Awaited<ReturnType<typeof createServerClient>>
+    );
+    await getMyStore('user-1', 'seller');
+    expect(mapStoreRow).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'pending' }),
+      false
+    );
   });
 });

--- a/src/app/api/stores/_lib/service.test.ts
+++ b/src/app/api/stores/_lib/service.test.ts
@@ -134,7 +134,7 @@ describe('createStore', () => {
     expect(insertPayload).not.toHaveProperty('status');
     expect(insertPayload).not.toHaveProperty('created_at');
     expect(insertPayload).not.toHaveProperty('updated_at');
-    expect(mapStoreRow).toHaveBeenCalledWith(mockRow);
+    expect(mapStoreRow).toHaveBeenCalledWith(mockRow, false);
     expect(result).toBe(mockStoreResponse);
   });
 

--- a/src/app/api/stores/_lib/service.ts
+++ b/src/app/api/stores/_lib/service.ts
@@ -1,6 +1,8 @@
 import type { StoreResponse, CreateStoreRequest } from '@/contracts/store';
+import type { UserResponse } from '@/contracts/user';
 import { AppError } from '@/lib/errors/appError';
 import { ERROR_CODE } from '@/lib/errors/errorCodes';
+import { createServerClient } from '@/lib/supabase/server';
 import { createServiceRoleClient } from '@/lib/supabase/service';
 
 import { mapStoreRow } from './mapper';
@@ -47,4 +49,23 @@ export async function createStore(
   if (!row) throw new AppError(ERROR_CODE.INTERNAL_SERVER_ERROR, 500);
 
   return mapStoreRow(row, false);
+}
+
+export async function getMyStore(
+  userId: string,
+  userRole: UserResponse['role']
+): Promise<StoreResponse> {
+  const supabase = await createServerClient();
+
+  const { data, error } = await supabase
+    .from('stores')
+    .select('*')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) throw new AppError(ERROR_CODE.INTERNAL_SERVER_ERROR, 500);
+  if (data === null) throw new AppError(ERROR_CODE.STORE_NOT_FOUND, 404);
+
+  const canSell = userRole === 'seller' && data.status === 'approved';
+  return mapStoreRow(data, canSell);
 }

--- a/src/app/api/stores/_lib/service.ts
+++ b/src/app/api/stores/_lib/service.ts
@@ -46,5 +46,5 @@ export async function createStore(
   }
   if (!row) throw new AppError(ERROR_CODE.INTERNAL_SERVER_ERROR, 500);
 
-  return mapStoreRow(row);
+  return mapStoreRow(row, false);
 }

--- a/src/app/api/stores/me/route.test.ts
+++ b/src/app/api/stores/me/route.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { StoreResponse } from '@/contracts/store';
+import { AppError } from '@/lib/errors/appError';
+import { ERROR_CODE } from '@/lib/errors/errorCodes';
+import { requireActiveUser } from '@/app/api/_lib/auth';
+import { isApiMockEnabled } from '@/app/api/_lib/mock';
+
+import { GET, PATCH } from './route';
+import { getMyStore } from '../_lib/service';
+
+vi.mock('@/app/api/_lib/mock', () => ({
+  isApiMockEnabled: vi.fn(),
+}));
+
+vi.mock('@/app/api/_lib/auth', () => ({
+  requireActiveUser: vi.fn(),
+}));
+
+vi.mock('../_lib/service', () => ({
+  getMyStore: vi.fn(),
+}));
+
+const mockServiceUser = {
+  id: 'user-1',
+  role: 'seller' as const,
+  email: 'seller@example.com',
+  name: '판매자',
+  status: 'active' as const,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+describe('GET /api/stores/me', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('mock 모드', () => {
+    it('mockMyStore를 200으로 반환한다', async () => {
+      vi.mocked(isApiMockEnabled).mockReturnValue(true);
+      const res = await GET();
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        statusCode: number;
+        data: StoreResponse;
+      };
+      expect(body.statusCode).toBe(200);
+      expect(body.data).toBeDefined();
+    });
+  });
+
+  describe('real 모드', () => {
+    beforeEach(() => {
+      vi.mocked(isApiMockEnabled).mockReturnValue(false);
+      vi.mocked(requireActiveUser).mockResolvedValue({
+        authUser: {} as Awaited<
+          ReturnType<typeof requireActiveUser>
+        >['authUser'],
+        serviceUser: mockServiceUser,
+      });
+    });
+
+    it('service가 가게를 반환하면 200을 반환한다', async () => {
+      vi.mocked(getMyStore).mockResolvedValue({} as StoreResponse);
+      const res = await GET();
+      expect(res.status).toBe(200);
+    });
+
+    it('STORE_NOT_FOUND throw 시 404를 반환한다', async () => {
+      vi.mocked(getMyStore).mockRejectedValue(
+        new AppError(ERROR_CODE.STORE_NOT_FOUND, 404)
+      );
+      const res = await GET();
+      expect(res.status).toBe(404);
+      const body = (await res.json()) as { error: { code: string } };
+      expect(body.error.code).toBe('STORE_NOT_FOUND');
+    });
+
+    it('UNAUTHORIZED throw 시 401을 반환한다', async () => {
+      vi.mocked(requireActiveUser).mockRejectedValue(
+        new AppError(ERROR_CODE.UNAUTHORIZED, 401)
+      );
+      const res = await GET();
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error: { code: string } };
+      expect(body.error.code).toBe('UNAUTHORIZED');
+    });
+  });
+});
+
+describe('PATCH /api/stores/me', () => {
+  it('NOT_IMPLEMENTED(501)을 반환한다', async () => {
+    const res = await PATCH();
+    expect(res.status).toBe(501);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('NOT_IMPLEMENTED');
+  });
+});

--- a/src/app/api/stores/me/route.ts
+++ b/src/app/api/stores/me/route.ts
@@ -4,7 +4,7 @@ import { isApiMockEnabled } from '@/app/api/_lib/mock';
 import { fail, routeError, success } from '@/app/api/_lib/response';
 import { mockMyStore } from '@/mocks/stores';
 
-import { getMyStore } from './../_lib/service';
+import { getMyStore } from '../_lib/service';
 
 export async function GET(): Promise<Response> {
   try {

--- a/src/app/api/stores/me/route.ts
+++ b/src/app/api/stores/me/route.ts
@@ -1,12 +1,24 @@
 import { ERROR_CODE } from '@/lib/errors/errorCodes';
+import { requireActiveUser } from '@/app/api/_lib/auth';
 import { isApiMockEnabled } from '@/app/api/_lib/mock';
-import { fail, success } from '@/app/api/_lib/response';
+import { fail, routeError, success } from '@/app/api/_lib/response';
 import { mockMyStore } from '@/mocks/stores';
 
-export async function GET(): Promise<Response> {
-  if (!isApiMockEnabled()) {
-    return fail(ERROR_CODE.NOT_IMPLEMENTED);
-  }
+import { getMyStore } from './../_lib/service';
 
-  return success(mockMyStore);
+export async function GET(): Promise<Response> {
+  try {
+    if (isApiMockEnabled()) {
+      return success(mockMyStore);
+    }
+    const { serviceUser } = await requireActiveUser();
+    const store = await getMyStore(serviceUser.id, serviceUser.role);
+    return success(store);
+  } catch (error) {
+    return routeError(error);
+  }
+}
+
+export async function PATCH(): Promise<Response> {
+  return fail(ERROR_CODE.NOT_IMPLEMENTED);
 }

--- a/src/hooks/stores/useMyStore.ts
+++ b/src/hooks/stores/useMyStore.ts
@@ -6,7 +6,7 @@ import type { MyStore } from '@/types/store';
 import { storeApi } from '@/api/stores/storeApi';
 
 export function useMyStore() {
-  return useQuery<MyStore>({
+  return useQuery<MyStore | null>({
     queryKey: ['stores', 'my'],
     queryFn: () => storeApi.getMyStore(),
   });


### PR DESCRIPTION
## 📌 작업 내용

- 가게 상태 조회 API를 구현하였습니다

## 🔧 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 📂 주요 변경 파일

- `src/app/api/stores/me/route.ts`
- `src/api/stores/storeApi.ts`
- `src/hooks/stores/useMyStore.ts`

## 🧪 테스트 방법

- 임시 테스트 페이지 구현 후 기능 확인

## 🔗 관련 이슈

- closes #63 
