### PR TITLE
Feat/#51/menu manage layout

### DIFF
--- a/src/app/(seller)/seller/menu/_components/MenuManageContent.tsx
+++ b/src/app/(seller)/seller/menu/_components/MenuManageContent.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { Package, ShoppingBag, PackageX } from 'lucide-react';
+
+import { Button } from '@/components/common/Button/Button';
+import { Section } from '@/components/common/Section/Section';
+
+export function MenuManageContent() {
+  // TODO: API 연동 시 실제 데이터로 교체
+  const stats = {
+    total: 32,
+    onSale: 28,
+    stopped: 4,
+  };
+
+  const handleAddMenu = () => {
+    // TODO: 메뉴 등록 모달 또는 페이지 이동
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className="text-xl font-bold text-gray-900 lg:text-2xl">
+          메뉴 목록
+        </h1>
+        <p className="mt-1 text-sm text-gray-500">
+          등록한 메뉴를 확인하고 관리할 수 있습니다.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <Section variant="card" className="bg-white">
+          <div className="flex items-center gap-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
+              <Package className="h-6 w-6 text-gray-600" />
+            </div>
+            <div>
+              <p className="text-sm text-gray-500">전체 메뉴</p>
+              <p className="text-2xl font-bold text-gray-900">
+                {stats.total}
+                <span className="text-base font-normal text-gray-500">개</span>
+              </p>
+            </div>
+          </div>
+        </Section>
+
+        <Section variant="card" className="bg-white">
+          <div className="flex items-center gap-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+              <ShoppingBag className="h-6 w-6 text-green-600" />
+            </div>
+            <div>
+              <p className="text-sm text-gray-500">판매중</p>
+              <p className="text-2xl font-bold text-gray-900">
+                {stats.onSale}
+                <span className="text-base font-normal text-gray-500">개</span>
+              </p>
+            </div>
+          </div>
+        </Section>
+
+        <Section variant="card" className="bg-white">
+          <div className="flex items-center gap-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+              <PackageX className="h-6 w-6 text-red-600" />
+            </div>
+            <div>
+              <p className="text-sm text-gray-500">판매중지</p>
+              <p className="text-2xl font-bold text-gray-900">
+                {stats.stopped}
+                <span className="text-base font-normal text-gray-500">개</span>
+              </p>
+            </div>
+          </div>
+        </Section>
+      </div>
+
+      <Section variant="card" className="bg-white">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            {/* TODO: 필터, 검색 영역 - 다음 PR */}
+          </div>
+          <Button onClick={handleAddMenu}>+ 메뉴 등록</Button>
+        </div>
+
+        <div className="mt-6 flex min-h-[300px] items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50">
+          <div className="text-center">
+            <Package className="mx-auto h-12 w-12 text-gray-300" />
+            <p className="mt-2 text-sm text-gray-500">
+              등록된 메뉴가 없습니다.
+            </p>
+            <p className="text-xs text-gray-400">
+              메뉴를 등록하고 판매를 시작해보세요.
+            </p>
+          </div>
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/src/app/(seller)/seller/menu/page.tsx
+++ b/src/app/(seller)/seller/menu/page.tsx
@@ -1,0 +1,5 @@
+import { MenuManageContent } from './_components/MenuManageContent';
+
+export default function SellerMenuPage() {
+  return <MenuManageContent />;
+}

--- a/src/app/(seller)/seller/register/_components/DocumentStep.tsx
+++ b/src/app/(seller)/seller/register/_components/DocumentStep.tsx
@@ -211,10 +211,10 @@ export function DocumentStep({
 
           return (
             <div key={doc.id} className="flex flex-col gap-2">
-              <label className="text-sm font-medium text-gray-700">
+              <span className="text-sm font-medium text-gray-700">
                 {doc.title}
                 {doc.required && <span className="ml-1 text-red-500">*</span>}
-              </label>
+              </span>
 
               {uploadedFile ? (
                 <div className="flex items-center justify-between rounded-lg border border-green-200 bg-green-50 px-4 py-3">
@@ -239,12 +239,13 @@ export function DocumentStep({
                   </button>
                 </div>
               ) : (
-                <div
+                <label
+                  htmlFor={doc.id}
                   onDrop={handleDrop(doc.id)}
                   onDragOver={handleDragOver(doc.id)}
                   onDragLeave={handleDragLeave(doc.id)}
                   className={cn(
-                    'flex flex-col items-center justify-center rounded-lg border-2 border-dashed px-4 py-6 transition-colors',
+                    'flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed px-4 py-6 transition-colors',
                     getDropzoneClass(dragging, hasError)
                   )}
                 >
@@ -255,14 +256,7 @@ export function DocumentStep({
                     )}
                   />
                   <p className="mb-1 text-sm text-gray-600">
-                    파일을 드래그하거나{' '}
-                    <label
-                      htmlFor={doc.id}
-                      className="text-primary-500 hover:text-primary-600 cursor-pointer font-medium"
-                    >
-                      직접 선택
-                    </label>
-                    하세요
+                    파일을 드래그하거나 클릭하여 선택하세요
                   </p>
                   <p className="text-xs text-gray-400">{doc.description}</p>
                   <input
@@ -272,7 +266,7 @@ export function DocumentStep({
                     className="sr-only"
                     onChange={handleInputChange(doc.id)}
                   />
-                </div>
+                </label>
               )}
 
               {errors[doc.id] && (

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,6 +11,7 @@ const SELLER_PROTECTED = [
   '/seller/products',
   '/seller/orders',
   '/seller/store',
+  '/seller/menu',
 ];
 const ADMIN_PROTECTED = ['/admin'];
 


### PR DESCRIPTION
## 📌 작업 내용

- 판매자 메뉴 관리 페이지 기본 라우트 및 레이아웃 구현
- 파일 업로드 드롭존 전체 영역 클릭 가능하도록 개선

## 🔧 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 📂 주요 변경 파일

- src/app/(seller)/seller/menu/page.tsx
- src/app/(seller)/seller/menu/_components/MenuManageContent.tsx
- src/app/(seller)/seller/register/_components/DocumentStep.tsx

## 🧪 테스트 방법

- /seller/menu 페이지 접속
- 페이지 타이틀, 통계 카드, 메뉴 등록 버튼 표시 확인

## 📸 스크린샷 (선택)

<img width="1945" height="928" alt="스크린샷 2026-05-11 오후 2 56 30" src="https://github.com/user-attachments/assets/e13157d1-ac3d-45c8-bb22-f0c0315f6648" />

## 🔗 관련 이슈

- ex) close #51 
