### PR TITLE
feat: 주문 결제 패널 UI 구현

### DIFF
--- a/src/components/consumer/order/OrderCheckoutPanel.tsx
+++ b/src/components/consumer/order/OrderCheckoutPanel.tsx
@@ -1,8 +1,12 @@
+'use client';
+
 import { Clock, CreditCard, MapPin } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 
 import type { ProductDetailResponse } from '@/contracts/product';
 import { Button } from '@/components/common';
+
+import { PickupTimeChangeModal } from './PickupTimeChangeModal';
 
 interface OrderCheckoutPanelProps {
   product: ProductDetailResponse;
@@ -12,7 +16,8 @@ interface OrderCheckoutPanelProps {
 interface OrderInfoBlockProps {
   icon: ReactNode;
   title: string;
-  actionLabel: string;
+  actionLabel?: string;
+  onAction?: () => void;
   children: ReactNode;
 }
 
@@ -38,60 +43,75 @@ export function OrderCheckoutPanel({
   finalPaymentPrice,
 }: OrderCheckoutPanelProps) {
   const pickupPlace = getPickupPlace(product);
-  const pickupTime = `${formatPickupTime(product.pickupStartTime)}~${formatPickupTime(
+  const defaultPickupTime = `${formatPickupTime(product.pickupStartTime)}~${formatPickupTime(
     product.pickupEndTime
   )}`;
+  const [pickupTime, setPickupTime] = useState(defaultPickupTime);
+  const [isPickupTimeModalOpen, setIsPickupTimeModalOpen] = useState(false);
 
   return (
-    <section className="rounded-lg border border-gray-200 bg-white p-8">
-      <OrderInfoBlock
-        icon={<MapPin className="size-5" aria-hidden="true" />}
-        title="픽업 정보"
-        actionLabel="변경"
-      >
-        <p className="font-medium text-gray-900">{pickupPlace}</p>
-        <p className="mt-2 text-sm text-gray-600">
-          매장 방문 후 주문 상품을 수령해 주세요.
-        </p>
-      </OrderInfoBlock>
+    <>
+      <section className="rounded-lg border border-gray-200 bg-white p-8">
+        <OrderInfoBlock
+          icon={<MapPin className="size-6" aria-hidden="true" />}
+          title="픽업 정보"
+        >
+          <p className="text-base font-medium text-gray-900">{pickupPlace}</p>
+          <p className="mt-2 text-sm text-gray-600">
+            매장 방문 후 주문 상품을 수령해 주세요.
+          </p>
+        </OrderInfoBlock>
 
-      <OrderInfoBlock
-        icon={<Clock className="size-5" aria-hidden="true" />}
-        title="픽업 시간"
-        actionLabel="변경"
-      >
-        <p className="font-medium text-gray-900">오늘 {pickupTime}</p>
-      </OrderInfoBlock>
+        <OrderInfoBlock
+          icon={<Clock className="size-5" aria-hidden="true" />}
+          title="픽업 시간"
+          actionLabel="변경"
+          onAction={() => setIsPickupTimeModalOpen(true)}
+        >
+          <p className="font-medium text-gray-900">오늘 {pickupTime}</p>
+        </OrderInfoBlock>
 
-      <OrderInfoBlock
-        icon={<CreditCard className="size-5" aria-hidden="true" />}
-        title="결제 수단"
-        actionLabel="변경"
-      >
-        <p className="font-medium text-gray-900">신용/체크카드</p>
-        <p className="mt-2 text-sm text-gray-500">
-          결제 수단은 추후 연동 예정입니다.
-        </p>
-      </OrderInfoBlock>
+        <OrderInfoBlock
+          icon={<CreditCard className="size-5" aria-hidden="true" />}
+          title="결제 수단"
+        >
+          <p className="font-medium text-gray-900">토스페이먼츠</p>
+          <p className="mt-2 text-sm text-gray-500">
+            결제 수단은 추후 연동 예정입니다.
+          </p>
+        </OrderInfoBlock>
 
-      <div className="mt-8 border-t border-gray-200 pt-7">
-        <div className="mb-6 flex items-center justify-between">
-          <h2 className="text-lg font-bold text-gray-900">최종 결제 금액</h2>
-          <strong className="text-primary-500 text-2xl font-bold">
-            {finalPaymentPrice.toLocaleString()}원
-          </strong>
+        <div className="mt-8 border-t border-gray-200 pt-7">
+          <div className="mb-6 flex items-center justify-between">
+            <h2 className="text-lg font-bold text-gray-900">최종 결제 금액</h2>
+            <strong className="text-primary-500 text-2xl font-bold">
+              {finalPaymentPrice.toLocaleString()}원
+            </strong>
+          </div>
+
+          {/* TODO: 주문 생성 API 호출 후 토스페이먼츠 결제 위젯을 연결합니다. */}
+          <Button className="w-full py-4 text-lg font-bold">
+            {finalPaymentPrice.toLocaleString()}원 결제하기
+          </Button>
+
+          <p className="mt-5 text-center text-xs leading-5 text-gray-500">
+            결제 버튼을 누르면 픽마의 이용약관과 개인정보 처리방침에 동의하게
+            됩니다.
+          </p>
         </div>
+      </section>
 
-        <Button className="w-full py-4 text-lg font-bold">
-          {finalPaymentPrice.toLocaleString()}원 결제하기
-        </Button>
-
-        <p className="mt-5 text-center text-xs leading-5 text-gray-500">
-          결제 버튼을 누르면 픽마의 이용약관과 개인정보 처리방침에 동의하게
-          됩니다.
-        </p>
-      </div>
-    </section>
+      {isPickupTimeModalOpen ? (
+        <PickupTimeChangeModal
+          isOpen={isPickupTimeModalOpen}
+          selectedPickupTime={pickupTime}
+          pickupStartTime={product.pickupStartTime}
+          pickupEndTime={product.pickupEndTime}
+          onChangePickupTime={setPickupTime}
+          onClose={() => setIsPickupTimeModalOpen(false)}
+        />
+      ) : null}
+    </>
   );
 }
 
@@ -99,18 +119,22 @@ function OrderInfoBlock({
   icon,
   title,
   actionLabel,
+  onAction,
   children,
 }: OrderInfoBlockProps) {
   return (
     <div className="border-b border-gray-200 py-7 first:pt-0">
       <div className="mb-5 flex items-center justify-between">
         <h2 className="text-lg font-bold text-gray-900">{title}</h2>
-        <button
-          type="button"
-          className="rounded-md border border-gray-200 px-4 py-2 text-sm font-semibold text-gray-700"
-        >
-          {actionLabel}
-        </button>
+        {actionLabel ? (
+          <button
+            type="button"
+            onClick={onAction}
+            className="rounded-md border border-gray-200 px-4 py-2 text-sm font-semibold text-gray-700"
+          >
+            {actionLabel}
+          </button>
+        ) : null}
       </div>
       <div className="flex gap-3 text-sm">
         <span className="mt-0.5 text-gray-600">{icon}</span>

--- a/src/components/consumer/order/OrderCheckoutPanel.tsx
+++ b/src/components/consumer/order/OrderCheckoutPanel.tsx
@@ -59,7 +59,7 @@ export function OrderCheckoutPanel({
   finalPaymentPrice,
 }: OrderCheckoutPanelProps) {
   const pickupPlace = getPickupPlace(product);
-  const [referenceNow] = useState(() => new Date());
+  const [referenceNow, setReferenceNow] = useState(() => new Date());
   const pickupDateLabel = formatPickupDateLabel(
     product.pickupStartTime,
     referenceNow
@@ -71,6 +71,10 @@ export function OrderCheckoutPanel({
     )
   );
   const [isPickupTimeModalOpen, setIsPickupTimeModalOpen] = useState(false);
+  const handleOpenPickupTimeModal = () => {
+    setReferenceNow(new Date());
+    setIsPickupTimeModalOpen(true);
+  };
 
   return (
     <>
@@ -89,10 +93,10 @@ export function OrderCheckoutPanel({
           icon={<Clock className="size-5" aria-hidden="true" />}
           title="픽업 시간"
           actionLabel="변경"
-          onAction={() => setIsPickupTimeModalOpen(true)}
+          onAction={handleOpenPickupTimeModal}
         >
           <p className="font-medium text-gray-900">
-            {pickupDateLabel} {pickupTime.label}
+            {pickupDateLabel ? `${pickupDateLabel} ${pickupTime.label}` : '-'}
           </p>
         </OrderInfoBlock>
 

--- a/src/components/consumer/order/OrderCheckoutPanel.tsx
+++ b/src/components/consumer/order/OrderCheckoutPanel.tsx
@@ -7,6 +7,7 @@ import type { ProductDetailResponse } from '@/contracts/product';
 import {
   formatPickupDateLabel,
   formatPickupTime,
+  type PickupTimeOption,
 } from '@/lib/formatPickupTime';
 import { Button } from '@/components/common';
 
@@ -39,16 +40,36 @@ function getPickupPlace(product: ProductDetailResponse) {
     : product.store.address;
 }
 
+function createDefaultPickupTimeOption(
+  pickupStartTime: string,
+  pickupEndTime: string
+): PickupTimeOption {
+  const startAt = formatPickupTime(pickupStartTime);
+  const endAt = formatPickupTime(pickupEndTime);
+
+  return {
+    label: `${startAt}~${endAt}`,
+    startAt,
+    endAt,
+  };
+}
+
 export function OrderCheckoutPanel({
   product,
   finalPaymentPrice,
 }: OrderCheckoutPanelProps) {
   const pickupPlace = getPickupPlace(product);
-  const defaultPickupTime = `${formatPickupTime(product.pickupStartTime)}~${formatPickupTime(
-    product.pickupEndTime
-  )}`;
-  const pickupDateLabel = formatPickupDateLabel(product.pickupStartTime);
-  const [pickupTime, setPickupTime] = useState(defaultPickupTime);
+  const [referenceNow] = useState(() => new Date());
+  const pickupDateLabel = formatPickupDateLabel(
+    product.pickupStartTime,
+    referenceNow
+  );
+  const [pickupTime, setPickupTime] = useState(() =>
+    createDefaultPickupTimeOption(
+      product.pickupStartTime,
+      product.pickupEndTime
+    )
+  );
   const [isPickupTimeModalOpen, setIsPickupTimeModalOpen] = useState(false);
 
   return (
@@ -71,7 +92,7 @@ export function OrderCheckoutPanel({
           onAction={() => setIsPickupTimeModalOpen(true)}
         >
           <p className="font-medium text-gray-900">
-            {pickupDateLabel} {pickupTime}
+            {pickupDateLabel} {pickupTime.label}
           </p>
         </OrderInfoBlock>
 
@@ -111,6 +132,7 @@ export function OrderCheckoutPanel({
           selectedPickupTime={pickupTime}
           pickupStartTime={product.pickupStartTime}
           pickupEndTime={product.pickupEndTime}
+          referenceNow={referenceNow}
           onChangePickupTime={setPickupTime}
           onClose={() => setIsPickupTimeModalOpen(false)}
         />

--- a/src/components/consumer/order/OrderCheckoutPanel.tsx
+++ b/src/components/consumer/order/OrderCheckoutPanel.tsx
@@ -4,6 +4,10 @@ import { Clock, CreditCard, MapPin } from 'lucide-react';
 import { useState, type ReactNode } from 'react';
 
 import type { ProductDetailResponse } from '@/contracts/product';
+import {
+  formatPickupDateLabel,
+  formatPickupTime,
+} from '@/lib/formatPickupTime';
 import { Button } from '@/components/common';
 
 import { PickupTimeChangeModal } from './PickupTimeChangeModal';
@@ -13,24 +17,21 @@ interface OrderCheckoutPanelProps {
   finalPaymentPrice: number;
 }
 
-interface OrderInfoBlockProps {
-  icon: ReactNode;
-  title: string;
-  actionLabel?: string;
-  onAction?: () => void;
-  children: ReactNode;
-}
-
-function formatPickupTime(value: string) {
-  const time = value.includes('T') ? value.split('T')[1] : value;
-  const [hour, minute] = time.split(':');
-
-  if (!hour || !minute) {
-    return value;
-  }
-
-  return `${hour.padStart(2, '0')}:${minute.padStart(2, '0')}`;
-}
+type OrderInfoBlockProps =
+  | {
+      icon: ReactNode;
+      title: string;
+      actionLabel: string;
+      onAction: () => void;
+      children: ReactNode;
+    }
+  | {
+      icon: ReactNode;
+      title: string;
+      actionLabel?: undefined;
+      onAction?: undefined;
+      children: ReactNode;
+    };
 
 function getPickupPlace(product: ProductDetailResponse) {
   return product.store.addressDetail
@@ -46,6 +47,7 @@ export function OrderCheckoutPanel({
   const defaultPickupTime = `${formatPickupTime(product.pickupStartTime)}~${formatPickupTime(
     product.pickupEndTime
   )}`;
+  const pickupDateLabel = formatPickupDateLabel(product.pickupStartTime);
   const [pickupTime, setPickupTime] = useState(defaultPickupTime);
   const [isPickupTimeModalOpen, setIsPickupTimeModalOpen] = useState(false);
 
@@ -68,7 +70,9 @@ export function OrderCheckoutPanel({
           actionLabel="변경"
           onAction={() => setIsPickupTimeModalOpen(true)}
         >
-          <p className="font-medium text-gray-900">오늘 {pickupTime}</p>
+          <p className="font-medium text-gray-900">
+            {pickupDateLabel} {pickupTime}
+          </p>
         </OrderInfoBlock>
 
         <OrderInfoBlock

--- a/src/components/consumer/order/PickupTimeChangeModal.tsx
+++ b/src/components/consumer/order/PickupTimeChangeModal.tsx
@@ -1,6 +1,11 @@
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useState } from 'react';
 
+import {
+  createPickupTimeOptions,
+  formatPickupDateLabel,
+  isPastPickupTimeSlot,
+} from '@/lib/formatPickupTime';
 import { Button, Modal } from '@/components/common';
 
 interface PickupTimeChangeModalProps {
@@ -10,112 +15,6 @@ interface PickupTimeChangeModalProps {
   pickupEndTime: string;
   onChangePickupTime: (pickupTime: string) => void;
   onClose: () => void;
-}
-
-function parseTimeToMinutes(value: string) {
-  const time = value.includes('T') ? value.split('T')[1] : value;
-  const [hour, minute] = time.split(':').map(Number);
-
-  if (
-    Number.isNaN(hour) ||
-    Number.isNaN(minute) ||
-    hour < 0 ||
-    hour > 23 ||
-    minute < 0 ||
-    minute > 59
-  ) {
-    return null;
-  }
-
-  return hour * 60 + minute;
-}
-
-function formatMinutesToTime(totalMinutes: number) {
-  const hour = Math.floor(totalMinutes / 60);
-  const minute = totalMinutes % 60;
-
-  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
-}
-
-function createPickupTimeOptions(startTime: string, endTime: string) {
-  const start = parseTimeToMinutes(startTime);
-  const end = parseTimeToMinutes(endTime);
-  const options: string[] = [];
-
-  if (start === null || end === null || start >= end) {
-    return options;
-  }
-
-  for (let current = start; current + 30 <= end; current += 30) {
-    const next = current + 30;
-    options.push(
-      `${formatMinutesToTime(current)}~${formatMinutesToTime(next)}`
-    );
-  }
-
-  return options;
-}
-
-function formatPickupDate(value: string) {
-  if (!value.includes('T')) {
-    return new Intl.DateTimeFormat('ko-KR', {
-      month: 'numeric',
-      day: 'numeric',
-      weekday: 'short',
-    }).format(new Date());
-  }
-
-  const date = new Date(value);
-
-  if (Number.isNaN(date.getTime())) {
-    return new Intl.DateTimeFormat('ko-KR', {
-      month: 'numeric',
-      day: 'numeric',
-      weekday: 'short',
-    }).format(new Date());
-  }
-
-  return new Intl.DateTimeFormat('ko-KR', {
-    month: 'numeric',
-    day: 'numeric',
-    weekday: 'short',
-  }).format(date);
-}
-
-function isPastTimeSlot(slotValue: string, pickupDateTime: string, now: Date) {
-  const [startTime] = slotValue.split('~');
-  const slotStartMinutes = parseTimeToMinutes(startTime);
-
-  if (slotStartMinutes === null) {
-    return true;
-  }
-
-  if (pickupDateTime.includes('T')) {
-    const pickupDate = new Date(pickupDateTime);
-
-    if (Number.isNaN(pickupDate.getTime())) {
-      return true;
-    }
-
-    const pickupDateOnly = new Date(
-      pickupDate.getFullYear(),
-      pickupDate.getMonth(),
-      pickupDate.getDate()
-    );
-    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-
-    if (pickupDateOnly.getTime() > today.getTime()) {
-      return false;
-    }
-
-    if (pickupDateOnly.getTime() < today.getTime()) {
-      return true;
-    }
-  }
-
-  const nowMinutes = now.getHours() * 60 + now.getMinutes();
-
-  return slotStartMinutes <= nowMinutes;
 }
 
 export function PickupTimeChangeModal({
@@ -130,14 +29,22 @@ export function PickupTimeChangeModal({
     pickupStartTime,
     pickupEndTime
   );
-  const initialDraftPickupTime = pickupTimeOptions.includes(selectedPickupTime)
-    ? selectedPickupTime
-    : '';
+  const now = new Date();
+  const initialDraftPickupTime =
+    pickupTimeOptions.includes(selectedPickupTime) &&
+    !isPastPickupTimeSlot(selectedPickupTime, pickupStartTime, now)
+      ? selectedPickupTime
+      : '';
   const [draftPickupTime, setDraftPickupTime] = useState(
     initialDraftPickupTime
   );
-  const pickupDate = formatPickupDate(pickupStartTime);
-  const now = new Date();
+  const pickupDateLabel = formatPickupDateLabel(pickupStartTime, now);
+  const isDraftPickupTimePast =
+    draftPickupTime !== '' &&
+    isPastPickupTimeSlot(draftPickupTime, pickupStartTime, now);
+  const hasAvailablePickupTime = pickupTimeOptions.some(
+    (time) => !isPastPickupTimeSlot(time, pickupStartTime, now)
+  );
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="픽업 시간 변경" size="md">
@@ -158,7 +65,7 @@ export function PickupTimeChangeModal({
             </button>
 
             <span className="text-base font-semibold text-gray-900">
-              오늘 {pickupDate}
+              {pickupDateLabel}
             </span>
 
             <button
@@ -180,7 +87,11 @@ export function PickupTimeChangeModal({
           <div className="grid max-h-42 grid-cols-3 gap-2 overflow-y-auto pr-1">
             {pickupTimeOptions.map((time) => {
               const isSelected = time === draftPickupTime;
-              const isDisabled = isPastTimeSlot(time, pickupStartTime, now);
+              const isDisabled = isPastPickupTimeSlot(
+                time,
+                pickupStartTime,
+                now
+              );
 
               return (
                 <Button
@@ -202,7 +113,7 @@ export function PickupTimeChangeModal({
               );
             })}
 
-            {pickupTimeOptions.length === 0 ? (
+            {!hasAvailablePickupTime ? (
               <p className="col-span-3 rounded-md border border-gray-200 p-4 text-sm text-gray-500">
                 선택 가능한 픽업 시간이 없습니다.
               </p>
@@ -221,7 +132,7 @@ export function PickupTimeChangeModal({
           </Button>
           <Button
             type="button"
-            disabled={draftPickupTime === ''}
+            disabled={draftPickupTime === '' || isDraftPickupTimePast}
             onClick={() => {
               onChangePickupTime(draftPickupTime);
               onClose();

--- a/src/components/consumer/order/PickupTimeChangeModal.tsx
+++ b/src/components/consumer/order/PickupTimeChangeModal.tsx
@@ -5,15 +5,17 @@ import {
   createPickupTimeOptions,
   formatPickupDateLabel,
   isPastPickupTimeSlot,
+  type PickupTimeOption,
 } from '@/lib/formatPickupTime';
 import { Button, Modal } from '@/components/common';
 
 interface PickupTimeChangeModalProps {
   isOpen: boolean;
-  selectedPickupTime: string;
+  selectedPickupTime: PickupTimeOption;
   pickupStartTime: string;
   pickupEndTime: string;
-  onChangePickupTime: (pickupTime: string) => void;
+  referenceNow: Date;
+  onChangePickupTime: (pickupTime: PickupTimeOption) => void;
   onClose: () => void;
 }
 
@@ -22,6 +24,7 @@ export function PickupTimeChangeModal({
   selectedPickupTime,
   pickupStartTime,
   pickupEndTime,
+  referenceNow,
   onChangePickupTime,
   onClose,
 }: PickupTimeChangeModalProps) {
@@ -29,21 +32,31 @@ export function PickupTimeChangeModal({
     pickupStartTime,
     pickupEndTime
   );
-  const now = new Date();
   const initialDraftPickupTime =
-    pickupTimeOptions.includes(selectedPickupTime) &&
-    !isPastPickupTimeSlot(selectedPickupTime, pickupStartTime, now)
+    pickupTimeOptions.find(
+      (option) => option.startAt === selectedPickupTime.startAt
+    ) &&
+    !isPastPickupTimeSlot(
+      selectedPickupTime.startAt,
+      pickupStartTime,
+      referenceNow
+    )
       ? selectedPickupTime
-      : '';
+      : null;
   const [draftPickupTime, setDraftPickupTime] = useState(
     initialDraftPickupTime
   );
-  const pickupDateLabel = formatPickupDateLabel(pickupStartTime, now);
+  const pickupDateLabel = formatPickupDateLabel(pickupStartTime, referenceNow);
   const isDraftPickupTimePast =
-    draftPickupTime !== '' &&
-    isPastPickupTimeSlot(draftPickupTime, pickupStartTime, now);
+    draftPickupTime !== null &&
+    isPastPickupTimeSlot(
+      draftPickupTime.startAt,
+      pickupStartTime,
+      referenceNow
+    );
   const hasAvailablePickupTime = pickupTimeOptions.some(
-    (time) => !isPastPickupTimeSlot(time, pickupStartTime, now)
+    (option) =>
+      !isPastPickupTimeSlot(option.startAt, pickupStartTime, referenceNow)
   );
 
   return (
@@ -85,17 +98,17 @@ export function PickupTimeChangeModal({
           </h3>
 
           <div className="grid max-h-42 grid-cols-3 gap-2 overflow-y-auto pr-1">
-            {pickupTimeOptions.map((time) => {
-              const isSelected = time === draftPickupTime;
+            {pickupTimeOptions.map((option) => {
+              const isSelected = option.startAt === draftPickupTime?.startAt;
               const isDisabled = isPastPickupTimeSlot(
-                time,
+                option.startAt,
                 pickupStartTime,
-                now
+                referenceNow
               );
 
               return (
                 <Button
-                  key={time}
+                  key={option.startAt}
                   type="button"
                   variant="outline"
                   color={isSelected ? 'primary' : 'gray'}
@@ -106,9 +119,9 @@ export function PickupTimeChangeModal({
                     isSelected && !isDisabled ? 'bg-primary-50' : 'bg-white',
                     isDisabled ? 'text-gray-300' : '',
                   ].join(' ')}
-                  onClick={() => setDraftPickupTime(time)}
+                  onClick={() => setDraftPickupTime(option)}
                 >
-                  {time}
+                  {option.label}
                 </Button>
               );
             })}
@@ -132,9 +145,11 @@ export function PickupTimeChangeModal({
           </Button>
           <Button
             type="button"
-            disabled={draftPickupTime === '' || isDraftPickupTimePast}
+            disabled={draftPickupTime === null || isDraftPickupTimePast}
             onClick={() => {
-              onChangePickupTime(draftPickupTime);
+              if (draftPickupTime) {
+                onChangePickupTime(draftPickupTime);
+              }
               onClose();
             }}
           >

--- a/src/components/consumer/order/PickupTimeChangeModal.tsx
+++ b/src/components/consumer/order/PickupTimeChangeModal.tsx
@@ -64,7 +64,7 @@ export function PickupTimeChangeModal({
     setDraftPickupTime(pickupTime);
   };
   const handleConfirmPickupTimeChange = () => {
-    if (!draftPickupTime) {
+    if (!draftPickupTime || isDraftPickupTimePast) {
       return;
     }
 

--- a/src/components/consumer/order/PickupTimeChangeModal.tsx
+++ b/src/components/consumer/order/PickupTimeChangeModal.tsx
@@ -1,0 +1,236 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+
+import { Button, Modal } from '@/components/common';
+
+interface PickupTimeChangeModalProps {
+  isOpen: boolean;
+  selectedPickupTime: string;
+  pickupStartTime: string;
+  pickupEndTime: string;
+  onChangePickupTime: (pickupTime: string) => void;
+  onClose: () => void;
+}
+
+function parseTimeToMinutes(value: string) {
+  const time = value.includes('T') ? value.split('T')[1] : value;
+  const [hour, minute] = time.split(':').map(Number);
+
+  if (
+    Number.isNaN(hour) ||
+    Number.isNaN(minute) ||
+    hour < 0 ||
+    hour > 23 ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return null;
+  }
+
+  return hour * 60 + minute;
+}
+
+function formatMinutesToTime(totalMinutes: number) {
+  const hour = Math.floor(totalMinutes / 60);
+  const minute = totalMinutes % 60;
+
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+}
+
+function createPickupTimeOptions(startTime: string, endTime: string) {
+  const start = parseTimeToMinutes(startTime);
+  const end = parseTimeToMinutes(endTime);
+  const options: string[] = [];
+
+  if (start === null || end === null || start >= end) {
+    return options;
+  }
+
+  for (let current = start; current + 30 <= end; current += 30) {
+    const next = current + 30;
+    options.push(
+      `${formatMinutesToTime(current)}~${formatMinutesToTime(next)}`
+    );
+  }
+
+  return options;
+}
+
+function formatPickupDate(value: string) {
+  if (!value.includes('T')) {
+    return new Intl.DateTimeFormat('ko-KR', {
+      month: 'numeric',
+      day: 'numeric',
+      weekday: 'short',
+    }).format(new Date());
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return new Intl.DateTimeFormat('ko-KR', {
+      month: 'numeric',
+      day: 'numeric',
+      weekday: 'short',
+    }).format(new Date());
+  }
+
+  return new Intl.DateTimeFormat('ko-KR', {
+    month: 'numeric',
+    day: 'numeric',
+    weekday: 'short',
+  }).format(date);
+}
+
+function isPastTimeSlot(slotValue: string, pickupDateTime: string, now: Date) {
+  const [startTime] = slotValue.split('~');
+  const slotStartMinutes = parseTimeToMinutes(startTime);
+
+  if (slotStartMinutes === null) {
+    return true;
+  }
+
+  if (pickupDateTime.includes('T')) {
+    const pickupDate = new Date(pickupDateTime);
+
+    if (Number.isNaN(pickupDate.getTime())) {
+      return true;
+    }
+
+    const pickupDateOnly = new Date(
+      pickupDate.getFullYear(),
+      pickupDate.getMonth(),
+      pickupDate.getDate()
+    );
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+    if (pickupDateOnly.getTime() > today.getTime()) {
+      return false;
+    }
+
+    if (pickupDateOnly.getTime() < today.getTime()) {
+      return true;
+    }
+  }
+
+  const nowMinutes = now.getHours() * 60 + now.getMinutes();
+
+  return slotStartMinutes <= nowMinutes;
+}
+
+export function PickupTimeChangeModal({
+  isOpen,
+  selectedPickupTime,
+  pickupStartTime,
+  pickupEndTime,
+  onChangePickupTime,
+  onClose,
+}: PickupTimeChangeModalProps) {
+  const pickupTimeOptions = createPickupTimeOptions(
+    pickupStartTime,
+    pickupEndTime
+  );
+  const initialDraftPickupTime = pickupTimeOptions.includes(selectedPickupTime)
+    ? selectedPickupTime
+    : '';
+  const [draftPickupTime, setDraftPickupTime] = useState(
+    initialDraftPickupTime
+  );
+  const pickupDate = formatPickupDate(pickupStartTime);
+  const now = new Date();
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="픽업 시간 변경" size="md">
+      <div className="space-y-6">
+        <div>
+          <h3 className="mb-4 text-base font-semibold text-gray-900">
+            픽업 날짜
+          </h3>
+
+          <div className="flex items-center justify-between rounded-md border border-gray-200 px-4 py-3">
+            <button
+              type="button"
+              aria-label="이전 날짜"
+              disabled
+              className="text-gray-300 disabled:cursor-not-allowed"
+            >
+              <ChevronLeft className="size-5" aria-hidden="true" />
+            </button>
+
+            <span className="text-base font-semibold text-gray-900">
+              오늘 {pickupDate}
+            </span>
+
+            <button
+              type="button"
+              aria-label="다음 날짜"
+              disabled
+              className="text-gray-300 disabled:cursor-not-allowed"
+            >
+              <ChevronRight className="size-5" aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+
+        <div>
+          <h3 className="mb-4 text-base font-semibold text-gray-900">
+            시간 선택
+          </h3>
+
+          <div className="grid max-h-42 grid-cols-3 gap-2 overflow-y-auto pr-1">
+            {pickupTimeOptions.map((time) => {
+              const isSelected = time === draftPickupTime;
+              const isDisabled = isPastTimeSlot(time, pickupStartTime, now);
+
+              return (
+                <Button
+                  key={time}
+                  type="button"
+                  variant="outline"
+                  color={isSelected ? 'primary' : 'gray'}
+                  aria-pressed={isSelected}
+                  disabled={isDisabled}
+                  className={[
+                    'h-auto rounded-md px-3 py-3 text-sm',
+                    isSelected && !isDisabled ? 'bg-primary-50' : 'bg-white',
+                    isDisabled ? 'text-gray-300' : '',
+                  ].join(' ')}
+                  onClick={() => setDraftPickupTime(time)}
+                >
+                  {time}
+                </Button>
+              );
+            })}
+
+            {pickupTimeOptions.length === 0 ? (
+              <p className="col-span-3 rounded-md border border-gray-200 p-4 text-sm text-gray-500">
+                선택 가능한 픽업 시간이 없습니다.
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button
+            type="button"
+            variant="outline"
+            color="gray"
+            onClick={onClose}
+          >
+            취소
+          </Button>
+          <Button
+            type="button"
+            disabled={draftPickupTime === ''}
+            onClick={() => {
+              onChangePickupTime(draftPickupTime);
+              onClose();
+            }}
+          >
+            변경하기
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/consumer/order/PickupTimeChangeModal.tsx
+++ b/src/components/consumer/order/PickupTimeChangeModal.tsx
@@ -47,6 +47,7 @@ export function PickupTimeChangeModal({
     initialDraftPickupTime
   );
   const pickupDateLabel = formatPickupDateLabel(pickupStartTime, referenceNow);
+  const hasValidPickupDate = pickupDateLabel !== null;
   const isDraftPickupTimePast =
     draftPickupTime !== null &&
     isPastPickupTimeSlot(
@@ -56,8 +57,20 @@ export function PickupTimeChangeModal({
     );
   const hasAvailablePickupTime = pickupTimeOptions.some(
     (option) =>
+      hasValidPickupDate &&
       !isPastPickupTimeSlot(option.startAt, pickupStartTime, referenceNow)
   );
+  const handleSelectPickupTime = (pickupTime: PickupTimeOption) => {
+    setDraftPickupTime(pickupTime);
+  };
+  const handleConfirmPickupTimeChange = () => {
+    if (!draftPickupTime) {
+      return;
+    }
+
+    onChangePickupTime(draftPickupTime);
+    onClose();
+  };
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="픽업 시간 변경" size="md">
@@ -78,7 +91,7 @@ export function PickupTimeChangeModal({
             </button>
 
             <span className="text-base font-semibold text-gray-900">
-              {pickupDateLabel}
+              {pickupDateLabel ?? '-'}
             </span>
 
             <button
@@ -113,13 +126,13 @@ export function PickupTimeChangeModal({
                   variant="outline"
                   color={isSelected ? 'primary' : 'gray'}
                   aria-pressed={isSelected}
-                  disabled={isDisabled}
+                  disabled={!hasValidPickupDate || isDisabled}
                   className={[
                     'h-auto rounded-md px-3 py-3 text-sm',
                     isSelected && !isDisabled ? 'bg-primary-50' : 'bg-white',
                     isDisabled ? 'text-gray-300' : '',
                   ].join(' ')}
-                  onClick={() => setDraftPickupTime(option)}
+                  onClick={() => handleSelectPickupTime(option)}
                 >
                   {option.label}
                 </Button>
@@ -146,12 +159,7 @@ export function PickupTimeChangeModal({
           <Button
             type="button"
             disabled={draftPickupTime === null || isDraftPickupTimePast}
-            onClick={() => {
-              if (draftPickupTime) {
-                onChangePickupTime(draftPickupTime);
-              }
-              onClose();
-            }}
+            onClick={handleConfirmPickupTimeChange}
           >
             변경하기
           </Button>

--- a/src/lib/formatPickupTime.ts
+++ b/src/lib/formatPickupTime.ts
@@ -14,7 +14,7 @@ function getPickupDate(value: string, now: Date) {
   const date = new Date(value);
 
   if (Number.isNaN(date.getTime())) {
-    return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    return null;
   }
 
   return date;
@@ -46,6 +46,11 @@ function addDays(value: Date, days: number) {
 
 export function formatPickupDateLabel(value: string, now = new Date()) {
   const pickupDate = getPickupDate(value, now);
+
+  if (pickupDate === null) {
+    return null;
+  }
+
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const tomorrow = addDays(today, 1);
   const formattedDate = formatPickupDate(pickupDate);
@@ -149,6 +154,11 @@ export function isPastPickupTimeSlot(
   }
 
   const pickupDate = getPickupDate(pickupDateTime, now);
+
+  if (pickupDate === null) {
+    return true;
+  }
+
   const pickupDateOnly = new Date(
     pickupDate.getFullYear(),
     pickupDate.getMonth(),

--- a/src/lib/formatPickupTime.ts
+++ b/src/lib/formatPickupTime.ts
@@ -1,5 +1,11 @@
 const TIME_ONLY_PATTERN = /^(\d{2}):(\d{2})(?::\d{2})?$/;
 
+export interface PickupTimeOption {
+  label: string;
+  startAt: string;
+  endAt: string;
+}
+
 function getPickupDate(value: string, now: Date) {
   if (!value.includes('T')) {
     return new Date(now.getFullYear(), now.getMonth(), now.getDate());
@@ -110,7 +116,7 @@ export function formatPickupTime(value: string) {
 export function createPickupTimeOptions(startTime: string, endTime: string) {
   const start = parsePickupTimeToMinutes(startTime);
   const end = parsePickupTimeToMinutes(endTime);
-  const options: string[] = [];
+  const options: PickupTimeOption[] = [];
 
   if (start === null || end === null || start >= end) {
     return options;
@@ -118,21 +124,25 @@ export function createPickupTimeOptions(startTime: string, endTime: string) {
 
   for (let current = start; current + 30 <= end; current += 30) {
     const next = current + 30;
-    options.push(
-      `${formatMinutesToTime(current)}~${formatMinutesToTime(next)}`
-    );
+    const optionStartTime = formatMinutesToTime(current);
+    const optionEndTime = formatMinutesToTime(next);
+
+    options.push({
+      label: `${optionStartTime}~${optionEndTime}`,
+      startAt: optionStartTime,
+      endAt: optionEndTime,
+    });
   }
 
   return options;
 }
 
 export function isPastPickupTimeSlot(
-  slotValue: string,
+  pickupStartTime: string,
   pickupDateTime: string,
   now: Date
 ) {
-  const [startTime] = slotValue.split('~');
-  const slotStartMinutes = parsePickupTimeToMinutes(startTime);
+  const slotStartMinutes = parsePickupTimeToMinutes(pickupStartTime);
 
   if (slotStartMinutes === null) {
     return true;

--- a/src/lib/formatPickupTime.ts
+++ b/src/lib/formatPickupTime.ts
@@ -1,24 +1,160 @@
 const TIME_ONLY_PATTERN = /^(\d{2}):(\d{2})(?::\d{2})?$/;
 
-export function formatPickupTime(value: string) {
-  const timeOnlyMatch = value.match(TIME_ONLY_PATTERN);
-
-  if (timeOnlyMatch) {
-    const [, hours, minutes] = timeOnlyMatch;
-
-    return `${hours}:${minutes}`;
+function getPickupDate(value: string, now: Date) {
+  if (!value.includes('T')) {
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate());
   }
 
   const date = new Date(value);
 
   if (Number.isNaN(date.getTime())) {
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  }
+
+  return date;
+}
+
+function formatPickupDate(value: Date) {
+  return new Intl.DateTimeFormat('ko-KR', {
+    month: 'numeric',
+    day: 'numeric',
+    weekday: 'short',
+  }).format(value);
+}
+
+function isSameDate(a: Date, b: Date) {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function addDays(value: Date, days: number) {
+  return new Date(
+    value.getFullYear(),
+    value.getMonth(),
+    value.getDate() + days
+  );
+}
+
+export function formatPickupDateLabel(value: string, now = new Date()) {
+  const pickupDate = getPickupDate(value, now);
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const tomorrow = addDays(today, 1);
+  const formattedDate = formatPickupDate(pickupDate);
+
+  if (isSameDate(pickupDate, today)) {
+    return `오늘 ${formattedDate}`;
+  }
+
+  if (isSameDate(pickupDate, tomorrow)) {
+    return `내일 ${formattedDate}`;
+  }
+
+  return formattedDate;
+}
+
+export function parsePickupTimeToMinutes(value: string) {
+  if (value.includes('T')) {
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+
+    return date.getHours() * 60 + date.getMinutes();
+  }
+
+  const timeOnlyMatch = value.match(TIME_ONLY_PATTERN);
+
+  if (!timeOnlyMatch) {
+    return null;
+  }
+
+  const [, hours, minutes] = timeOnlyMatch;
+  const hour = Number(hours);
+  const minute = Number(minutes);
+
+  if (
+    Number.isNaN(hour) ||
+    Number.isNaN(minute) ||
+    hour < 0 ||
+    hour > 23 ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return null;
+  }
+
+  return hour * 60 + minute;
+}
+
+function formatMinutesToTime(totalMinutes: number) {
+  const hour = Math.floor(totalMinutes / 60);
+  const minute = totalMinutes % 60;
+
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+}
+
+export function formatPickupTime(value: string) {
+  const minutes = parsePickupTimeToMinutes(value);
+
+  if (minutes === null) {
     return value;
   }
 
-  return new Intl.DateTimeFormat('ko-KR', {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-    timeZone: 'Asia/Seoul',
-  }).format(date);
+  return formatMinutesToTime(minutes);
+}
+
+export function createPickupTimeOptions(startTime: string, endTime: string) {
+  const start = parsePickupTimeToMinutes(startTime);
+  const end = parsePickupTimeToMinutes(endTime);
+  const options: string[] = [];
+
+  if (start === null || end === null || start >= end) {
+    return options;
+  }
+
+  for (let current = start; current + 30 <= end; current += 30) {
+    const next = current + 30;
+    options.push(
+      `${formatMinutesToTime(current)}~${formatMinutesToTime(next)}`
+    );
+  }
+
+  return options;
+}
+
+export function isPastPickupTimeSlot(
+  slotValue: string,
+  pickupDateTime: string,
+  now: Date
+) {
+  const [startTime] = slotValue.split('~');
+  const slotStartMinutes = parsePickupTimeToMinutes(startTime);
+
+  if (slotStartMinutes === null) {
+    return true;
+  }
+
+  const pickupDate = getPickupDate(pickupDateTime, now);
+  const pickupDateOnly = new Date(
+    pickupDate.getFullYear(),
+    pickupDate.getMonth(),
+    pickupDate.getDate()
+  );
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+  if (pickupDateOnly.getTime() > today.getTime()) {
+    return false;
+  }
+
+  if (pickupDateOnly.getTime() < today.getTime()) {
+    return true;
+  }
+
+  const nowMinutes = now.getHours() * 60 + now.getMinutes();
+
+  return slotStartMinutes <= nowMinutes;
 }


### PR DESCRIPTION
## 📌 작업 내용

- 주문/결제 페이지 오른쪽 결제 패널 UI를 구현했습니다.
- 배송 정보, 픽업 시간, 결제 수단, 최종 결제 금액 영역을 구성했습니다.
- 픽업 시간 변경 모달을 추가하고, 날짜/시간 선택 UI를 구현했습니다.

## 🔧 변경 사항

- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📂 주요 변경 파일

- src/components/consumer/order/OrderCheckoutPanel.tsx
- src/components/consumer/order/PickupTimeChangeModal.tsx
- src/lib/pickupTime.ts
- src/app/(consumer)/order/[productId]/page.tsx

## 🧪 테스트 방법

- `/order/[productId]` 페이지 접속
- 오른쪽 결제 패널이 정상적으로 표시되는지 확인
- 픽업 시간 변경 버튼 클릭 시 모달이 열리는지 확인
- 픽업 시간 선택 후 패널의 시간이 변경되는지 확인
- 과거 시간 슬롯이 비활성화되는지 확인
- 선택 가능한 시간이 없을 때 안내 문구가 표시되는지 확인

## 📌 참고 사항

- 실제 결제 수단 변경 및 토스페이먼츠 연동은 아직 포함하지 않았습니다.
- 결제하기 버튼의 실제 결제 요청 연결은 후속 이슈에서 진행할 예정입니다.
- 상품 상세 페이지에서 선택한 픽업 시간/수량을 주문 페이지로 전달하는 흐름은 API 연동 단계에서 함께 정리할 예정입니다.

## 📸 스크린샷 (선택)

- x
- 
## 🔗 관련 이슈

- close #75
