### PR TITLE
feat: 상품 상세 페이지 API 연동

### DIFF
--- a/src/app/(consumer)/products/[productId]/page.tsx
+++ b/src/app/(consumer)/products/[productId]/page.tsx
@@ -1,68 +1,12 @@
-import { notFound } from 'next/navigation';
-
-import type { ApiSuccess } from '@/contracts/common';
-import type { ProductDetailResponse } from '@/contracts/product';
-import { mapProductDetail } from '@/api/products/productMapper';
 import { ProductDetailContainer } from '@/components/consumer/ProductDetailContainer';
-import { productIdSchema } from '@/app/api/products/_lib/schemas';
 
 interface ProductDetailPageProps {
   params: Promise<{ productId: string }>;
 }
 
-const PRODUCT_DETAIL_FETCH_TIMEOUT_MS = 5000;
-
 export default async function ProductDetailPage({
   params,
 }: ProductDetailPageProps) {
   const { productId } = await params;
-  const parsed = productIdSchema.safeParse(productId);
-
-  if (!parsed.success) {
-    notFound();
-  }
-
-  const product = await getProductDetailOrNotFound(parsed.data);
-
-  return (
-    <ProductDetailContainer productId={parsed.data} initialProduct={product} />
-  );
-}
-
-async function getProductDetailOrNotFound(productId: string) {
-  const response = await fetch(`${getAppOrigin()}/api/products/${productId}`, {
-    cache: 'no-store',
-    signal: AbortSignal.timeout(PRODUCT_DETAIL_FETCH_TIMEOUT_MS),
-  });
-
-  if (response.status === 404) {
-    notFound();
-  }
-
-  if (!response.ok) {
-    throw new Error('Failed to fetch product detail');
-  }
-
-  const body = (await response.json()) as ApiSuccess<ProductDetailResponse>;
-  return mapProductDetail(body.data);
-}
-
-function getAppOrigin() {
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
-
-  if (!appUrl) {
-    if (process.env.NODE_ENV !== 'production') {
-      return `http://localhost:${process.env.PORT ?? '3000'}`;
-    }
-
-    throw new Error('Missing NEXT_PUBLIC_APP_URL');
-  }
-
-  const origin = new URL(appUrl).origin;
-
-  if (!origin.startsWith('http://') && !origin.startsWith('https://')) {
-    throw new Error('Invalid NEXT_PUBLIC_APP_URL');
-  }
-
-  return origin;
+  return <ProductDetailContainer productId={productId} />;
 }

--- a/src/app/(consumer)/products/[productId]/page.tsx
+++ b/src/app/(consumer)/products/[productId]/page.tsx
@@ -1,4 +1,14 @@
+import { notFound } from 'next/navigation';
+
+import { AppError } from '@/lib/errors/appError';
+import { ERROR_CODE } from '@/lib/errors/errorCodes';
+import { createServerClient } from '@/lib/supabase/server';
+import { mapProductDetail } from '@/api/products/productMapper';
 import { ProductDetailContainer } from '@/components/consumer/ProductDetailContainer';
+import { isApiMockEnabled } from '@/app/api/_lib/mock';
+import { productIdSchema } from '@/app/api/products/_lib/schemas';
+import { getProductById } from '@/app/api/products/_lib/service';
+import { mockProductDetailsMap } from '@/mocks/products';
 
 interface ProductDetailPageProps {
   params: Promise<{ productId: string }>;
@@ -8,6 +18,43 @@ export default async function ProductDetailPage({
   params,
 }: ProductDetailPageProps) {
   const { productId } = await params;
+  const parsed = productIdSchema.safeParse(productId);
 
-  return <ProductDetailContainer productId={productId} />;
+  if (!parsed.success) {
+    notFound();
+  }
+
+  const product = await getProductDetailOrNotFound(parsed.data);
+
+  return (
+    <ProductDetailContainer productId={parsed.data} initialProduct={product} />
+  );
+}
+
+async function getProductDetailOrNotFound(productId: string) {
+  if (isApiMockEnabled()) {
+    const product = mockProductDetailsMap[productId];
+
+    if (!product) {
+      notFound();
+    }
+
+    return mapProductDetail(product);
+  }
+
+  try {
+    const supabase = await createServerClient();
+    const product = await getProductById(supabase, productId);
+
+    return mapProductDetail(product);
+  } catch (error) {
+    if (
+      error instanceof AppError &&
+      error.code === ERROR_CODE.PRODUCT_NOT_FOUND
+    ) {
+      notFound();
+    }
+
+    throw error;
+  }
 }

--- a/src/app/(consumer)/products/[productId]/page.tsx
+++ b/src/app/(consumer)/products/[productId]/page.tsx
@@ -1,4 +1,3 @@
-import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
 
 import type { ApiSuccess } from '@/contracts/common';
@@ -10,6 +9,8 @@ import { productIdSchema } from '@/app/api/products/_lib/schemas';
 interface ProductDetailPageProps {
   params: Promise<{ productId: string }>;
 }
+
+const PRODUCT_DETAIL_FETCH_TIMEOUT_MS = 5000;
 
 export default async function ProductDetailPage({
   params,
@@ -29,20 +30,10 @@ export default async function ProductDetailPage({
 }
 
 async function getProductDetailOrNotFound(productId: string) {
-  const requestHeaders = await headers();
-  const host = requestHeaders.get('host');
-
-  if (!host) {
-    throw new Error('Missing request host');
-  }
-
-  const protocol = requestHeaders.get('x-forwarded-proto') ?? 'http';
-  const response = await fetch(
-    `${protocol}://${host}/api/products/${productId}`,
-    {
-      cache: 'no-store',
-    }
-  );
+  const response = await fetch(`${getAppOrigin()}/api/products/${productId}`, {
+    cache: 'no-store',
+    signal: AbortSignal.timeout(PRODUCT_DETAIL_FETCH_TIMEOUT_MS),
+  });
 
   if (response.status === 404) {
     notFound();
@@ -54,4 +45,24 @@ async function getProductDetailOrNotFound(productId: string) {
 
   const body = (await response.json()) as ApiSuccess<ProductDetailResponse>;
   return mapProductDetail(body.data);
+}
+
+function getAppOrigin() {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+
+  if (!appUrl) {
+    if (process.env.NODE_ENV !== 'production') {
+      return `http://localhost:${process.env.PORT ?? '3000'}`;
+    }
+
+    throw new Error('Missing NEXT_PUBLIC_APP_URL');
+  }
+
+  const origin = new URL(appUrl).origin;
+
+  if (!origin.startsWith('http://') && !origin.startsWith('https://')) {
+    throw new Error('Invalid NEXT_PUBLIC_APP_URL');
+  }
+
+  return origin;
 }

--- a/src/app/(consumer)/products/[productId]/page.tsx
+++ b/src/app/(consumer)/products/[productId]/page.tsx
@@ -1,11 +1,4 @@
-import { notFound } from 'next/navigation';
-
-import { Footer, Header } from '@/components/common';
-import { ProductDetailInfo } from '@/components/consumer/ProductDetailInfo';
-import { ProductDetailTabs } from '@/components/consumer/ProductDetailTabs';
-import { ProductImageGallery } from '@/components/consumer/ProductImageGallery';
-import { ProductReservationPanel } from '@/components/consumer/ProductReservationPanel';
-import { mockProductDetailsMap } from '@/mocks/products';
+import { ProductDetailContainer } from '@/components/consumer/ProductDetailContainer';
 
 interface ProductDetailPageProps {
   params: Promise<{ productId: string }>;
@@ -15,41 +8,6 @@ export default async function ProductDetailPage({
   params,
 }: ProductDetailPageProps) {
   const { productId } = await params;
-  const product = mockProductDetailsMap[productId];
 
-  if (!product) {
-    notFound();
-  }
-
-  return (
-    <div className="bg-white">
-      <Header user={null} logoHref="/" />
-
-      <main className="min-h-screen bg-white">
-        <section className="mx-auto grid max-w-450 gap-8 px-6 py-10 lg:grid-cols-[minmax(0,1fr)_400px] xl:grid-cols-[minmax(0,1fr)_460px]">
-          <div className="grid gap-8 xl:grid-cols-[560px_minmax(0,1fr)]">
-            <ProductImageGallery
-              productName={product.name}
-              imageUrl={product.image}
-            />
-
-            <ProductDetailInfo product={product} />
-          </div>
-
-          <aside className="lg:sticky lg:top-24 lg:self-start">
-            <ProductReservationPanel
-              price={product.discountPrice}
-              availableStock={product.availableStock}
-              pickupStartTime={product.pickupStartTime}
-              pickupEndTime={product.pickupEndTime}
-            />
-          </aside>
-        </section>
-
-        <ProductDetailTabs product={product} />
-      </main>
-
-      <Footer />
-    </div>
-  );
+  return <ProductDetailContainer productId={productId} />;
 }

--- a/src/app/(consumer)/products/[productId]/page.tsx
+++ b/src/app/(consumer)/products/[productId]/page.tsx
@@ -1,5 +1,9 @@
+import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
 
+import type { ApiSuccess } from '@/contracts/common';
+import type { ProductDetailResponse } from '@/contracts/product';
+import { mapProductDetail } from '@/api/products/productMapper';
 import { ProductDetailContainer } from '@/components/consumer/ProductDetailContainer';
 import { productIdSchema } from '@/app/api/products/_lib/schemas';
 
@@ -17,5 +21,37 @@ export default async function ProductDetailPage({
     notFound();
   }
 
-  return <ProductDetailContainer productId={parsed.data} />;
+  const product = await getProductDetailOrNotFound(parsed.data);
+
+  return (
+    <ProductDetailContainer productId={parsed.data} initialProduct={product} />
+  );
+}
+
+async function getProductDetailOrNotFound(productId: string) {
+  const requestHeaders = await headers();
+  const host = requestHeaders.get('host');
+
+  if (!host) {
+    throw new Error('Missing request host');
+  }
+
+  const protocol = requestHeaders.get('x-forwarded-proto') ?? 'http';
+  const response = await fetch(
+    `${protocol}://${host}/api/products/${productId}`,
+    {
+      cache: 'no-store',
+    }
+  );
+
+  if (response.status === 404) {
+    notFound();
+  }
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch product detail');
+  }
+
+  const body = (await response.json()) as ApiSuccess<ProductDetailResponse>;
+  return mapProductDetail(body.data);
 }

--- a/src/app/(consumer)/products/[productId]/page.tsx
+++ b/src/app/(consumer)/products/[productId]/page.tsx
@@ -1,14 +1,7 @@
 import { notFound } from 'next/navigation';
 
-import { AppError } from '@/lib/errors/appError';
-import { ERROR_CODE } from '@/lib/errors/errorCodes';
-import { createServerClient } from '@/lib/supabase/server';
-import { mapProductDetail } from '@/api/products/productMapper';
 import { ProductDetailContainer } from '@/components/consumer/ProductDetailContainer';
-import { isApiMockEnabled } from '@/app/api/_lib/mock';
 import { productIdSchema } from '@/app/api/products/_lib/schemas';
-import { getProductById } from '@/app/api/products/_lib/service';
-import { mockProductDetailsMap } from '@/mocks/products';
 
 interface ProductDetailPageProps {
   params: Promise<{ productId: string }>;
@@ -24,37 +17,5 @@ export default async function ProductDetailPage({
     notFound();
   }
 
-  const product = await getProductDetailOrNotFound(parsed.data);
-
-  return (
-    <ProductDetailContainer productId={parsed.data} initialProduct={product} />
-  );
-}
-
-async function getProductDetailOrNotFound(productId: string) {
-  if (isApiMockEnabled()) {
-    const product = mockProductDetailsMap[productId];
-
-    if (!product) {
-      notFound();
-    }
-
-    return mapProductDetail(product);
-  }
-
-  try {
-    const supabase = await createServerClient();
-    const product = await getProductById(supabase, productId);
-
-    return mapProductDetail(product);
-  } catch (error) {
-    if (
-      error instanceof AppError &&
-      error.code === ERROR_CODE.PRODUCT_NOT_FOUND
-    ) {
-      notFound();
-    }
-
-    throw error;
-  }
+  return <ProductDetailContainer productId={parsed.data} />;
 }

--- a/src/components/consumer/ProductDetailContainer.tsx
+++ b/src/components/consumer/ProductDetailContainer.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { ProductDetail } from '@/types/product';
 import { useProduct } from '@/hooks/products/useProduct';
 import { Footer } from '@/components/common';
 
@@ -12,7 +11,6 @@ import { ProductReservationPanel } from './ProductReservationPanel';
 
 interface ProductDetailContainerProps {
   productId: string;
-  initialProduct: ProductDetail;
 }
 
 function getStatusMessage(params: { isFetching: boolean; isError: boolean }) {
@@ -37,14 +35,13 @@ function getStatusMessage(params: { isFetching: boolean; isError: boolean }) {
 
 export function ProductDetailContainer({
   productId,
-  initialProduct,
 }: ProductDetailContainerProps) {
   const {
-    data: product = initialProduct,
+    data: product,
     isError,
     isFetching,
     isLoading,
-  } = useProduct(productId, initialProduct);
+  } = useProduct(productId);
   const statusMessage = getStatusMessage({ isFetching, isError });
 
   if (isLoading) {
@@ -76,6 +73,20 @@ export function ProductDetailContainer({
             className="text-sm font-medium text-gray-500"
           >
             상품 정보를 불러오지 못했습니다.
+          </p>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  if (!product) {
+    return (
+      <div className="bg-white">
+        <ConsumerHeader />
+        <main className="flex min-h-screen items-center justify-center bg-white">
+          <p className="text-sm font-medium text-gray-500">
+            상품 정보를 확인할 수 없습니다.
           </p>
         </main>
         <Footer />

--- a/src/components/consumer/ProductDetailContainer.tsx
+++ b/src/components/consumer/ProductDetailContainer.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { ProductDetail } from '@/types/product';
 import { useProduct } from '@/hooks/products/useProduct';
 import { Footer } from '@/components/common';
 
@@ -12,7 +11,6 @@ import { ProductReservationPanel } from './ProductReservationPanel';
 
 interface ProductDetailContainerProps {
   productId: string;
-  initialProduct: ProductDetail;
 }
 
 function getStatusMessage(params: { isFetching: boolean; isError: boolean }) {
@@ -37,14 +35,13 @@ function getStatusMessage(params: { isFetching: boolean; isError: boolean }) {
 
 export function ProductDetailContainer({
   productId,
-  initialProduct,
 }: ProductDetailContainerProps) {
   const {
-    data: product = initialProduct,
+    data: product,
     isError,
     isFetching,
     isLoading,
-  } = useProduct(productId, initialProduct);
+  } = useProduct(productId);
   const statusMessage = getStatusMessage({ isFetching, isError });
 
   if (isLoading) {

--- a/src/components/consumer/ProductDetailContainer.tsx
+++ b/src/components/consumer/ProductDetailContainer.tsx
@@ -22,6 +22,7 @@ export function ProductDetailContainer({
   const {
     data: product = initialProduct,
     isError,
+    isFetching,
     isLoading,
   } = useProduct(productId, initialProduct);
 
@@ -39,7 +40,7 @@ export function ProductDetailContainer({
     );
   }
 
-  if (isError || !product) {
+  if (isError && !product) {
     return (
       <div className="bg-white">
         <ConsumerHeader />
@@ -58,6 +59,19 @@ export function ProductDetailContainer({
       <ConsumerHeader />
 
       <main className="min-h-screen bg-white">
+        <div aria-live="polite" className="mx-auto max-w-450 px-6 pt-4">
+          {isFetching ? (
+            <p className="bg-primary-50 text-primary-500 rounded-md px-4 py-3 text-sm font-medium">
+              상품 정보를 최신 상태로 확인하는 중입니다.
+            </p>
+          ) : null}
+          {isError ? (
+            <p className="rounded-md bg-red-50 px-4 py-3 text-sm font-medium text-red-500">
+              최신 상품 정보를 불러오지 못해 이전 정보를 표시합니다.
+            </p>
+          ) : null}
+        </div>
+
         <section className="mx-auto grid max-w-450 gap-8 px-6 py-10 lg:grid-cols-[minmax(0,1fr)_400px] xl:grid-cols-[minmax(0,1fr)_460px]">
           <div className="grid gap-8 xl:grid-cols-[560px_minmax(0,1fr)]">
             <ProductImageGallery

--- a/src/components/consumer/ProductDetailContainer.tsx
+++ b/src/components/consumer/ProductDetailContainer.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useProduct } from '@/hooks/products/useProduct';
+import { Footer } from '@/components/common';
+
+import { ConsumerHeader } from './ConsumerHeader';
+import { ProductDetailInfo } from './ProductDetailInfo';
+import { ProductDetailTabs } from './ProductDetailTabs';
+import { ProductImageGallery } from './ProductImageGallery';
+import { ProductReservationPanel } from './ProductReservationPanel';
+
+interface ProductDetailContainerProps {
+  productId: string;
+}
+
+export function ProductDetailContainer({
+  productId,
+}: ProductDetailContainerProps) {
+  const { data: product, isError, isLoading } = useProduct(productId);
+
+  if (isLoading) {
+    return (
+      <div className="bg-white">
+        <ConsumerHeader />
+        <main className="flex min-h-screen items-center justify-center bg-white">
+          <p className="text-sm font-medium text-gray-500">
+            상품 정보를 불러오는 중입니다.
+          </p>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  if (isError || !product) {
+    return (
+      <div className="bg-white">
+        <ConsumerHeader />
+        <main className="flex min-h-screen items-center justify-center bg-white">
+          <p className="text-sm font-medium text-gray-500">
+            상품 정보를 불러오지 못했습니다.
+          </p>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white">
+      <ConsumerHeader />
+
+      <main className="min-h-screen bg-white">
+        <section className="mx-auto grid max-w-450 gap-8 px-6 py-10 lg:grid-cols-[minmax(0,1fr)_400px] xl:grid-cols-[minmax(0,1fr)_460px]">
+          <div className="grid gap-8 xl:grid-cols-[560px_minmax(0,1fr)]">
+            <ProductImageGallery
+              productName={product.name}
+              imageUrl={product.image}
+            />
+
+            <ProductDetailInfo product={product} />
+          </div>
+
+          <aside className="lg:sticky lg:top-24 lg:self-start">
+            <ProductReservationPanel
+              price={product.discountPrice}
+              availableStock={product.availableStock}
+              pickupStartTime={product.pickupStartTime}
+              pickupEndTime={product.pickupEndTime}
+            />
+          </aside>
+        </section>
+
+        <ProductDetailTabs product={product} />
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/consumer/ProductDetailContainer.tsx
+++ b/src/components/consumer/ProductDetailContainer.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ProductDetail } from '@/types/product';
 import { useProduct } from '@/hooks/products/useProduct';
 import { Footer } from '@/components/common';
 
@@ -11,6 +12,7 @@ import { ProductReservationPanel } from './ProductReservationPanel';
 
 interface ProductDetailContainerProps {
   productId: string;
+  initialProduct: ProductDetail;
 }
 
 function getStatusMessage(params: { isFetching: boolean; isError: boolean }) {
@@ -35,13 +37,14 @@ function getStatusMessage(params: { isFetching: boolean; isError: boolean }) {
 
 export function ProductDetailContainer({
   productId,
+  initialProduct,
 }: ProductDetailContainerProps) {
   const {
-    data: product,
+    data: product = initialProduct,
     isError,
     isFetching,
     isLoading,
-  } = useProduct(productId);
+  } = useProduct(productId, initialProduct);
   const statusMessage = getStatusMessage({ isFetching, isError });
 
   if (isLoading) {
@@ -128,6 +131,7 @@ export function ProductDetailContainer({
 
           <aside className="lg:sticky lg:top-24 lg:self-start">
             <ProductReservationPanel
+              productId={product.id}
               price={product.discountPrice}
               availableStock={product.availableStock}
               pickupStartTime={product.pickupStartTime}

--- a/src/components/consumer/ProductDetailContainer.tsx
+++ b/src/components/consumer/ProductDetailContainer.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ProductDetail } from '@/types/product';
 import { useProduct } from '@/hooks/products/useProduct';
 import { Footer } from '@/components/common';
 
@@ -11,12 +12,18 @@ import { ProductReservationPanel } from './ProductReservationPanel';
 
 interface ProductDetailContainerProps {
   productId: string;
+  initialProduct: ProductDetail;
 }
 
 export function ProductDetailContainer({
   productId,
+  initialProduct,
 }: ProductDetailContainerProps) {
-  const { data: product, isError, isLoading } = useProduct(productId);
+  const {
+    data: product = initialProduct,
+    isError,
+    isLoading,
+  } = useProduct(productId, initialProduct);
 
   if (isLoading) {
     return (

--- a/src/components/consumer/ProductDetailContainer.tsx
+++ b/src/components/consumer/ProductDetailContainer.tsx
@@ -15,6 +15,26 @@ interface ProductDetailContainerProps {
   initialProduct: ProductDetail;
 }
 
+function getStatusMessage(params: { isFetching: boolean; isError: boolean }) {
+  if (params.isFetching) {
+    return {
+      role: 'status' as const,
+      className: 'bg-primary-50 text-primary-500',
+      text: '상품 정보를 최신 상태로 확인하는 중입니다.',
+    };
+  }
+
+  if (params.isError) {
+    return {
+      role: 'alert' as const,
+      className: 'bg-red-50 text-red-500',
+      text: '최신 상품 정보를 불러오지 못해 이전 정보를 표시합니다.',
+    };
+  }
+
+  return null;
+}
+
 export function ProductDetailContainer({
   productId,
   initialProduct,
@@ -25,13 +45,18 @@ export function ProductDetailContainer({
     isFetching,
     isLoading,
   } = useProduct(productId, initialProduct);
+  const statusMessage = getStatusMessage({ isFetching, isError });
 
   if (isLoading) {
     return (
       <div className="bg-white">
         <ConsumerHeader />
         <main className="flex min-h-screen items-center justify-center bg-white">
-          <p className="text-sm font-medium text-gray-500">
+          <p
+            role="status"
+            aria-live="polite"
+            className="text-sm font-medium text-gray-500"
+          >
             상품 정보를 불러오는 중입니다.
           </p>
         </main>
@@ -45,7 +70,11 @@ export function ProductDetailContainer({
       <div className="bg-white">
         <ConsumerHeader />
         <main className="flex min-h-screen items-center justify-center bg-white">
-          <p className="text-sm font-medium text-gray-500">
+          <p
+            role="alert"
+            aria-live="assertive"
+            className="text-sm font-medium text-gray-500"
+          >
             상품 정보를 불러오지 못했습니다.
           </p>
         </main>
@@ -59,18 +88,22 @@ export function ProductDetailContainer({
       <ConsumerHeader />
 
       <main className="min-h-screen bg-white">
-        <div aria-live="polite" className="mx-auto max-w-450 px-6 pt-4">
-          {isFetching ? (
-            <p className="bg-primary-50 text-primary-500 rounded-md px-4 py-3 text-sm font-medium">
-              상품 정보를 최신 상태로 확인하는 중입니다.
+        {statusMessage ? (
+          <div className="mx-auto max-w-450 px-6 pt-4">
+            <p
+              role={statusMessage.role}
+              aria-live={
+                statusMessage.role === 'alert' ? 'assertive' : 'polite'
+              }
+              className={[
+                'rounded-md px-4 py-3 text-sm font-medium',
+                statusMessage.className,
+              ].join(' ')}
+            >
+              {statusMessage.text}
             </p>
-          ) : null}
-          {isError ? (
-            <p className="rounded-md bg-red-50 px-4 py-3 text-sm font-medium text-red-500">
-              최신 상품 정보를 불러오지 못해 이전 정보를 표시합니다.
-            </p>
-          ) : null}
-        </div>
+          </div>
+        ) : null}
 
         <section className="mx-auto grid max-w-450 gap-8 px-6 py-10 lg:grid-cols-[minmax(0,1fr)_400px] xl:grid-cols-[minmax(0,1fr)_460px]">
           <div className="grid gap-8 xl:grid-cols-[560px_minmax(0,1fr)]">

--- a/src/components/consumer/ProductDetailInfo.tsx
+++ b/src/components/consumer/ProductDetailInfo.tsx
@@ -1,14 +1,14 @@
 import type { ReactNode } from 'react';
 
-import type { ProductDetailResponse } from '@/contracts/product';
+import type { ProductDetail } from '@/types/product';
 import { formatPickupTime } from '@/lib/formatPickupTime';
 import { Badge } from '@/components/common';
 
 interface ProductDetailInfoProps {
-  product: ProductDetailResponse;
+  product: ProductDetail;
 }
 
-function getProductStatus(product: ProductDetailResponse) {
+function getProductStatus(product: ProductDetail) {
   if (
     product.isExpired ||
     product.displayStatus === 'expired' ||

--- a/src/components/consumer/ProductDetailTabs.tsx
+++ b/src/components/consumer/ProductDetailTabs.tsx
@@ -2,12 +2,12 @@
 
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react';
 
-import type { ProductDetailResponse } from '@/contracts/product';
+import type { ProductDetail } from '@/types/product';
 
 type ProductDetailTabId = 'detail' | 'review' | 'store';
 
 interface ProductDetailTabsProps {
-  product: ProductDetailResponse;
+  product: ProductDetail;
 }
 
 interface ProductDetailTab {

--- a/src/components/consumer/ProductReservationPanel.tsx
+++ b/src/components/consumer/ProductReservationPanel.tsx
@@ -12,6 +12,7 @@ import { useMemo, useState } from 'react';
 import { Button } from '@/components/common';
 
 interface ProductReservationPanelProps {
+  productId: string;
   price: number;
   availableStock: number;
   pickupStartTime: string;
@@ -118,6 +119,7 @@ function isPastTimeSlot(slotValue: string, pickupDateTime: string, now: Date) {
 }
 
 export function ProductReservationPanel({
+  productId,
   price,
   availableStock,
   pickupStartTime,
@@ -157,7 +159,8 @@ export function ProductReservationPanel({
       return;
     }
 
-    // TODO: 주문/결제 플로우 연동 시 선택한 픽업 시간과 수량을 전달합니다.
+    // TODO: 주문/결제 플로우 연동 시 productId, 선택한 픽업 시간, 수량을 전달합니다.
+    void productId;
   };
   const isDecreaseDisabled = quantity <= 1;
   const isIncreaseDisabled = quantity >= availableStock;

--- a/src/hooks/products/useProduct.ts
+++ b/src/hooks/products/useProduct.ts
@@ -5,11 +5,10 @@ import { useQuery } from '@tanstack/react-query';
 import type { ProductDetail } from '@/types/product';
 import { productApi } from '@/api/products/productApi';
 
-export function useProduct(id: string, initialData?: ProductDetail) {
+export function useProduct(id: string) {
   return useQuery<ProductDetail>({
     queryKey: ['products', 'detail', id],
     queryFn: () => productApi.getProduct(id),
     enabled: Boolean(id),
-    initialData,
   });
 }

--- a/src/hooks/products/useProduct.ts
+++ b/src/hooks/products/useProduct.ts
@@ -5,10 +5,11 @@ import { useQuery } from '@tanstack/react-query';
 import type { ProductDetail } from '@/types/product';
 import { productApi } from '@/api/products/productApi';
 
-export function useProduct(id: string) {
+export function useProduct(id: string, initialData?: ProductDetail) {
   return useQuery<ProductDetail>({
     queryKey: ['products', 'detail', id],
     queryFn: () => productApi.getProduct(id),
     enabled: Boolean(id),
+    initialData,
   });
 }


### PR DESCRIPTION
## 📌 작업 내용

- 상품 상세 페이지를 mock 직접 참조 방식에서 상품 상세 API 기반 렌더링으로 전환했습니다.
- 서버 컴포넌트에서 상품 존재 여부를 먼저 확인하고, 없는 상품은 `notFound()`로 처리하도록 수정했습니다.
- 클라이언트 영역은 `ProductDetailContainer`로 분리하여 상세 UI와 React Query 조회 흐름을 관리하도록 정리했습니다.

## 🔧 변경 사항

- [x] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 📂 주요 변경 파일

- `src/app/(consumer)/products/[productId]/page.tsx`
- `src/components/consumer/ProductDetailContainer.tsx`
- `src/hooks/products/useProduct.ts`
- `src/components/consumer/ProductDetailInfo.tsx`
- `src/components/consumer/ProductDetailTabs.tsx`

## 🧪 테스트 방법

- `/products/{productId}` 접속
- 존재하는 상품 ID로 상세 페이지가 정상 렌더링되는지 확인
- 존재하지 않는 상품 ID로 접근 시 404 처리되는지 확인
- mock API 활성화 상태에서도 기존 mock 상세 데이터가 정상 표시되는지 확인

## 📸 스크린샷 (선택)

- x

## 🔗 관련 이슈

- close #86 

## 📝 참고 사항

- 상세 페이지 최초 진입 시 서버에서 상품을 조회해 404 여부를 먼저 판단합니다.
- 클라이언트에서는 `useProduct`에 `initialData`를 전달해 동일 상품 데이터를 이어서 사용하도록 구성했습니다.
- 예약 패널의 실제 주문 생성/결제 연동은 후속 이슈에서 진행 예정입니다.
