### PR TITLE
feat: 마이페이지 기본 레이아웃 구현

### DIFF
--- a/src/app/(consumer)/mypage/page.tsx
+++ b/src/app/(consumer)/mypage/page.tsx
@@ -1,0 +1,31 @@
+import { Footer } from '@/components/common';
+import { ConsumerHeader } from '@/components/consumer/ConsumerHeader';
+import {
+  MypageReservationList,
+  MypageSidebar,
+  MypageSummaryPanel,
+} from '@/components/consumer/mypage';
+import { mockMypageReservations } from '@/mocks/mypage';
+
+export default function MypagePage() {
+  return (
+    <div className="bg-white">
+      <ConsumerHeader />
+
+      <main className="min-h-screen bg-white">
+        <div className="mx-auto grid max-w-450 grid-cols-1 lg:grid-cols-[270px_minmax(0,1fr)]">
+          <MypageSidebar />
+
+          <section className="px-5 py-10 lg:px-10">
+            <div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_360px]">
+              <MypageReservationList reservations={mockMypageReservations} />
+              <MypageSummaryPanel />
+            </div>
+          </section>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/consumer/mypage/MypageReservationCard.tsx
+++ b/src/components/consumer/mypage/MypageReservationCard.tsx
@@ -1,7 +1,6 @@
 import { MoreVertical } from 'lucide-react';
 import Image from 'next/image';
 
-import type { OrderStatusParam } from '@/contracts/order';
 import { Button } from '@/components/common';
 import type { MockMypageReservation } from '@/mocks/mypage';
 
@@ -11,8 +10,10 @@ interface MypageReservationCardProps {
 
 type ReservationStatusGroup = 'pendingPickup' | 'completed' | 'cancelled';
 
-const statusGroupMap: Record<OrderStatusParam, ReservationStatusGroup> = {
-  payment_pending: 'pendingPickup',
+const statusGroupMap: Record<
+  MockMypageReservation['status'],
+  ReservationStatusGroup
+> = {
   reserved: 'pendingPickup',
   ready: 'pendingPickup',
   completed: 'completed',

--- a/src/components/consumer/mypage/MypageReservationCard.tsx
+++ b/src/components/consumer/mypage/MypageReservationCard.tsx
@@ -104,6 +104,7 @@ export function MypageReservationCard({
           <Button
             variant="outline"
             color="gray"
+            disabled
             className="h-12 min-w-32 px-5 text-sm"
           >
             예약 상세보기
@@ -111,6 +112,7 @@ export function MypageReservationCard({
           <Button
             variant={status.actionVariant}
             color={statusGroup === 'pendingPickup' ? 'primary' : 'gray'}
+            disabled
             className="h-12 min-w-32 px-5 text-sm"
           >
             {status.actionLabel}
@@ -120,7 +122,8 @@ export function MypageReservationCard({
         <button
           type="button"
           aria-label="예약 메뉴 열기"
-          className="hidden rounded-sm p-1 text-gray-700 hover:bg-gray-50 md:block"
+          disabled
+          className="hidden cursor-not-allowed rounded-sm p-1 text-gray-400 md:block"
         >
           <MoreVertical className="size-5" aria-hidden="true" />
         </button>

--- a/src/components/consumer/mypage/MypageReservationCard.tsx
+++ b/src/components/consumer/mypage/MypageReservationCard.tsx
@@ -1,0 +1,130 @@
+import { MoreVertical } from 'lucide-react';
+import Image from 'next/image';
+
+import type { OrderStatusParam } from '@/contracts/order';
+import { Button } from '@/components/common';
+import type { MockMypageReservation } from '@/mocks/mypage';
+
+interface MypageReservationCardProps {
+  reservation: MockMypageReservation;
+}
+
+type ReservationStatusGroup = 'pendingPickup' | 'completed' | 'cancelled';
+
+const statusGroupMap: Record<OrderStatusParam, ReservationStatusGroup> = {
+  payment_pending: 'pendingPickup',
+  reserved: 'pendingPickup',
+  ready: 'pendingPickup',
+  completed: 'completed',
+  cancelled: 'cancelled',
+  no_show: 'cancelled',
+  expired: 'cancelled',
+};
+
+const statusStyles: Record<
+  ReservationStatusGroup,
+  {
+    label: string;
+    className: string;
+    actionLabel: string;
+    actionVariant: 'filled' | 'outline';
+  }
+> = {
+  pendingPickup: {
+    label: '픽업 대기',
+    className: 'bg-primary-50 text-primary-500',
+    actionLabel: '픽업 코드 보기',
+    actionVariant: 'filled',
+  },
+  completed: {
+    label: '픽업 완료',
+    className: 'bg-primary-50 text-primary-500',
+    actionLabel: '다시 예약',
+    actionVariant: 'outline',
+  },
+  cancelled: {
+    label: '취소/환불',
+    className: 'bg-gray-100 text-gray-500',
+    actionLabel: '내역 보기',
+    actionVariant: 'outline',
+  },
+};
+
+export function MypageReservationCard({
+  reservation,
+}: MypageReservationCardProps) {
+  const statusGroup = statusGroupMap[reservation.status];
+  const status = statusStyles[statusGroup];
+
+  return (
+    <article className="rounded-lg border border-gray-200 bg-white p-5">
+      <div className="grid gap-5 md:grid-cols-[150px_minmax(0,1fr)_120px_240px_24px] md:items-center">
+        <div className="relative aspect-square overflow-hidden rounded-md bg-gray-100">
+          <Image
+            src={reservation.imageUrl}
+            alt={reservation.productName}
+            fill
+            sizes="150px"
+            className="object-cover"
+          />
+        </div>
+
+        <div className="min-w-0">
+          <span
+            className={[
+              'inline-flex rounded-sm px-3 py-1 text-xs font-bold',
+              status.className,
+            ].join(' ')}
+          >
+            {status.label}
+          </span>
+          <p className="mt-4 text-base font-bold text-gray-900">
+            {reservation.storeName} {reservation.productName}
+          </p>
+          <dl className="mt-4 grid gap-2 text-sm md:grid-cols-[72px_minmax(0,1fr)]">
+            <dt className="text-gray-500">픽업 날짜</dt>
+            <dd className="text-gray-700">
+              {reservation.pickupDate} &nbsp; {reservation.pickupTime}
+            </dd>
+            <dt className="text-gray-500">주문번호</dt>
+            <dd className="text-gray-700">{reservation.orderNumber}</dd>
+          </dl>
+        </div>
+
+        <div>
+          <p className="text-xl font-bold text-gray-900">
+            {reservation.price.toLocaleString()}원
+          </p>
+          <p className="mt-2 text-sm text-gray-500">
+            수량&nbsp; {reservation.quantity}개
+          </p>
+        </div>
+
+        <div className="flex gap-2 md:justify-end">
+          <Button
+            variant="outline"
+            color="gray"
+            className="h-12 min-w-32 px-5 text-sm"
+          >
+            예약 상세보기
+          </Button>
+          <Button
+            variant={status.actionVariant}
+            color={statusGroup === 'pendingPickup' ? 'primary' : 'gray'}
+            className="h-12 min-w-32 px-5 text-sm"
+          >
+            {status.actionLabel}
+          </Button>
+        </div>
+
+        <button
+          type="button"
+          aria-label="예약 메뉴 열기"
+          className="hidden rounded-sm p-1 text-gray-700 hover:bg-gray-50 md:block"
+        >
+          <MoreVertical className="size-5" aria-hidden="true" />
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/src/components/consumer/mypage/MypageReservationCard.tsx
+++ b/src/components/consumer/mypage/MypageReservationCard.tsx
@@ -94,7 +94,7 @@ export function MypageReservationCard({
 
         <div>
           <p className="text-xl font-bold text-gray-900">
-            {reservation.price.toLocaleString()}원
+            {reservation.price.toLocaleString('ko-KR')}원
           </p>
           <p className="mt-2 text-sm text-gray-500">
             수량&nbsp; {reservation.quantity}개

--- a/src/components/consumer/mypage/MypageReservationList.tsx
+++ b/src/components/consumer/mypage/MypageReservationList.tsx
@@ -2,7 +2,6 @@
 
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react';
 
-import type { OrderStatusParam } from '@/contracts/order';
 import type { MockMypageReservation } from '@/mocks/mypage';
 
 import { MypageReservationCard } from './MypageReservationCard';
@@ -25,9 +24,9 @@ const reservationTabs: ReservationTab[] = [
 
 const tabStatusMap: Record<
   Exclude<ReservationTab['id'], 'all'>,
-  OrderStatusParam[]
+  MockMypageReservation['status'][]
 > = {
-  pendingPickup: ['payment_pending', 'reserved', 'ready'],
+  pendingPickup: ['reserved', 'ready'],
   completed: ['completed'],
   cancelled: ['cancelled', 'no_show', 'expired'],
 };

--- a/src/components/consumer/mypage/MypageReservationList.tsx
+++ b/src/components/consumer/mypage/MypageReservationList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react';
 
 import type { OrderStatusParam } from '@/contracts/order';
 import type { MockMypageReservation } from '@/mocks/mypage';
@@ -35,14 +35,6 @@ const tabStatusMap: Record<
 export function MypageReservationList({
   reservations,
 }: MypageReservationListProps) {
-  const [activeTabId, setActiveTabId] = useState<ReservationTab['id']>('all');
-  const filteredReservations =
-    activeTabId === 'all'
-      ? reservations
-      : reservations.filter((reservation) =>
-          tabStatusMap[activeTabId].includes(reservation.status)
-        );
-
   return (
     <section aria-labelledby="mypage-reservation-title">
       <h1
@@ -52,45 +44,72 @@ export function MypageReservationList({
         내 예약
       </h1>
 
-      <div className="mt-8 border-b border-gray-200">
-        <div className="flex gap-8" aria-label="예약 상태 필터">
+      <TabGroup>
+        <TabList
+          aria-label="예약 상태 필터"
+          className="mt-8 flex gap-8 border-b border-gray-200"
+        >
           {reservationTabs.map((tab) => {
-            const isActive = activeTabId === tab.id;
-
             return (
-              <button
+              <Tab
                 key={tab.id}
-                type="button"
-                aria-pressed={isActive}
-                className={[
-                  'focus-visible:ring-primary-500 border-b-2 px-3 py-4 text-base font-bold transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
-                  isActive
-                    ? 'border-primary-500 text-primary-500'
-                    : 'border-transparent text-gray-600 hover:text-gray-900',
-                ].join(' ')}
-                onClick={() => setActiveTabId(tab.id)}
+                className={({ selected }) =>
+                  [
+                    'focus-visible:ring-primary-500 rounded-sm border-b-2 px-3 py-4 text-base font-bold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+                    selected
+                      ? 'border-primary-500 text-primary-500'
+                      : 'border-transparent text-gray-600 hover:text-gray-900',
+                  ].join(' ')
+                }
               >
                 {tab.label}
-              </button>
+              </Tab>
             );
           })}
-        </div>
-      </div>
+        </TabList>
 
-      <div className="mt-6 max-h-[534px] space-y-4 overflow-y-auto pr-2">
-        {filteredReservations.map((reservation) => (
-          <MypageReservationCard
-            key={reservation.id}
-            reservation={reservation}
-          />
-        ))}
+        <TabPanels>
+          {reservationTabs.map((tab) => {
+            const filteredReservations = getFilteredReservations(
+              reservations,
+              tab.id
+            );
 
-        {filteredReservations.length === 0 ? (
-          <div className="flex min-h-60 items-center justify-center rounded-lg border border-dashed border-gray-200 bg-gray-50 text-sm font-medium text-gray-500">
-            해당 상태의 예약이 없습니다.
-          </div>
-        ) : null}
-      </div>
+            return (
+              <TabPanel
+                key={tab.id}
+                className="focus-visible:ring-primary-500 mt-6 max-h-[534px] space-y-4 overflow-y-auto rounded-sm pr-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+              >
+                {filteredReservations.map((reservation) => (
+                  <MypageReservationCard
+                    key={reservation.id}
+                    reservation={reservation}
+                  />
+                ))}
+
+                {filteredReservations.length === 0 ? (
+                  <div className="flex min-h-60 items-center justify-center rounded-lg border border-dashed border-gray-200 bg-gray-50 text-sm font-medium text-gray-500">
+                    해당 상태의 예약이 없습니다.
+                  </div>
+                ) : null}
+              </TabPanel>
+            );
+          })}
+        </TabPanels>
+      </TabGroup>
     </section>
+  );
+}
+
+function getFilteredReservations(
+  reservations: MockMypageReservation[],
+  activeTabId: ReservationTab['id']
+) {
+  if (activeTabId === 'all') {
+    return reservations;
+  }
+
+  return reservations.filter((reservation) =>
+    tabStatusMap[activeTabId].includes(reservation.status)
   );
 }

--- a/src/components/consumer/mypage/MypageReservationList.tsx
+++ b/src/components/consumer/mypage/MypageReservationList.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useState } from 'react';
+
+import type { OrderStatusParam } from '@/contracts/order';
+import type { MockMypageReservation } from '@/mocks/mypage';
+
+import { MypageReservationCard } from './MypageReservationCard';
+
+interface ReservationTab {
+  id: 'all' | 'pendingPickup' | 'completed' | 'cancelled';
+  label: string;
+}
+
+interface MypageReservationListProps {
+  reservations: MockMypageReservation[];
+}
+
+const reservationTabs: ReservationTab[] = [
+  { id: 'all', label: '전체 예약' },
+  { id: 'pendingPickup', label: '픽업 대기' },
+  { id: 'completed', label: '픽업 완료' },
+  { id: 'cancelled', label: '취소/환불' },
+];
+
+const tabStatusMap: Record<
+  Exclude<ReservationTab['id'], 'all'>,
+  OrderStatusParam[]
+> = {
+  pendingPickup: ['payment_pending', 'reserved', 'ready'],
+  completed: ['completed'],
+  cancelled: ['cancelled', 'no_show', 'expired'],
+};
+
+export function MypageReservationList({
+  reservations,
+}: MypageReservationListProps) {
+  const [activeTabId, setActiveTabId] = useState<ReservationTab['id']>('all');
+  const filteredReservations =
+    activeTabId === 'all'
+      ? reservations
+      : reservations.filter((reservation) =>
+          tabStatusMap[activeTabId].includes(reservation.status)
+        );
+
+  return (
+    <section aria-labelledby="mypage-reservation-title">
+      <h1
+        id="mypage-reservation-title"
+        className="text-2xl font-bold text-gray-900"
+      >
+        내 예약
+      </h1>
+
+      <div className="mt-8 border-b border-gray-200">
+        <div className="flex gap-8" aria-label="예약 상태 필터">
+          {reservationTabs.map((tab) => {
+            const isActive = activeTabId === tab.id;
+
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                aria-pressed={isActive}
+                className={[
+                  'focus-visible:ring-primary-500 border-b-2 px-3 py-4 text-base font-bold transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+                  isActive
+                    ? 'border-primary-500 text-primary-500'
+                    : 'border-transparent text-gray-600 hover:text-gray-900',
+                ].join(' ')}
+                onClick={() => setActiveTabId(tab.id)}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mt-6 max-h-[534px] space-y-4 overflow-y-auto pr-2">
+        {filteredReservations.map((reservation) => (
+          <MypageReservationCard
+            key={reservation.id}
+            reservation={reservation}
+          />
+        ))}
+
+        {filteredReservations.length === 0 ? (
+          <div className="flex min-h-60 items-center justify-center rounded-lg border border-dashed border-gray-200 bg-gray-50 text-sm font-medium text-gray-500">
+            해당 상태의 예약이 없습니다.
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/consumer/mypage/MypageSidebar.tsx
+++ b/src/components/consumer/mypage/MypageSidebar.tsx
@@ -1,0 +1,84 @@
+import {
+  CalendarCheck,
+  CircleHelp,
+  Megaphone,
+  MessageCircle,
+  Settings,
+  User,
+} from 'lucide-react';
+
+const menuItems = [
+  {
+    label: '내 예약',
+    icon: <CalendarCheck className="size-5" aria-hidden="true" />,
+    active: true,
+  },
+  {
+    label: '내 정보',
+    icon: <User className="size-5" aria-hidden="true" />,
+    active: false,
+  },
+  {
+    label: '설정',
+    icon: <Settings className="size-5" aria-hidden="true" />,
+    active: false,
+  },
+];
+
+const supportItems = [
+  {
+    label: '자주 묻는 질문',
+    icon: <CircleHelp className="size-5" aria-hidden="true" />,
+  },
+  {
+    label: '1:1 문의',
+    icon: <MessageCircle className="size-5" aria-hidden="true" />,
+  },
+  {
+    label: '공지사항',
+    icon: <Megaphone className="size-5" aria-hidden="true" />,
+  },
+];
+
+export function MypageSidebar() {
+  return (
+    <aside className="hidden border-r border-gray-200 px-10 py-10 lg:block">
+      <h2 className="text-lg font-bold text-gray-900">마이페이지</h2>
+
+      <nav className="mt-6 space-y-2" aria-label="마이페이지 메뉴">
+        {menuItems.map((item) => (
+          <button
+            key={item.label}
+            type="button"
+            className={[
+              'flex w-full items-center gap-3 rounded-md px-4 py-3 text-left text-base font-semibold',
+              item.active
+                ? 'bg-primary-50 text-primary-500'
+                : 'text-gray-700 hover:bg-gray-50',
+            ].join(' ')}
+            aria-current={item.active ? 'page' : undefined}
+          >
+            {item.icon}
+            {item.label}
+          </button>
+        ))}
+      </nav>
+
+      <div className="mt-8 border-t border-gray-200 pt-8">
+        <p className="text-base font-bold text-gray-900">고객센터</p>
+        <nav className="mt-4 space-y-2" aria-label="고객센터 메뉴">
+          {supportItems.map((item) => (
+            <button
+              key={item.label}
+              type="button"
+              className="flex w-full items-center gap-3 rounded-md px-4 py-3 text-left text-base font-medium text-gray-700 hover:bg-gray-50"
+            >
+              {item.icon}
+              {item.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/consumer/mypage/MypageSidebar.tsx
+++ b/src/components/consumer/mypage/MypageSidebar.tsx
@@ -50,8 +50,9 @@ export function MypageSidebar() {
           <button
             key={item.label}
             type="button"
+            disabled={!item.active}
             className={[
-              'flex w-full items-center gap-3 rounded-md px-4 py-3 text-left text-base font-semibold',
+              'flex w-full items-center gap-3 rounded-md px-4 py-3 text-left text-base font-semibold disabled:cursor-not-allowed disabled:opacity-50',
               item.active
                 ? 'bg-primary-50 text-primary-500'
                 : 'text-gray-700 hover:bg-gray-50',
@@ -71,7 +72,8 @@ export function MypageSidebar() {
             <button
               key={item.label}
               type="button"
-              className="flex w-full items-center gap-3 rounded-md px-4 py-3 text-left text-base font-medium text-gray-700 hover:bg-gray-50"
+              disabled
+              className="flex w-full cursor-not-allowed items-center gap-3 rounded-md px-4 py-3 text-left text-base font-medium text-gray-700 opacity-50"
             >
               {item.icon}
               {item.label}

--- a/src/components/consumer/mypage/MypageSummaryPanel.tsx
+++ b/src/components/consumer/mypage/MypageSummaryPanel.tsx
@@ -13,7 +13,8 @@ export function MypageSummaryPanel() {
           <h2 className="text-lg font-bold text-gray-900">내 정보</h2>
           <button
             type="button"
-            className="inline-flex items-center gap-1 text-sm font-medium text-gray-500"
+            disabled
+            className="inline-flex cursor-not-allowed items-center gap-1 text-sm font-medium text-gray-400"
           >
             수정하기
             <ChevronRight className="size-4" aria-hidden="true" />
@@ -63,7 +64,8 @@ export function MypageSummaryPanel() {
           <h2 className="text-lg font-bold text-gray-900">최근 본 상품</h2>
           <button
             type="button"
-            className="inline-flex items-center gap-1 text-sm font-medium text-gray-500"
+            disabled
+            className="inline-flex cursor-not-allowed items-center gap-1 text-sm font-medium text-gray-400"
           >
             전체보기
             <ChevronRight className="size-4" aria-hidden="true" />

--- a/src/components/consumer/mypage/MypageSummaryPanel.tsx
+++ b/src/components/consumer/mypage/MypageSummaryPanel.tsx
@@ -1,0 +1,91 @@
+import { ChevronRight, Ticket } from 'lucide-react';
+import Image from 'next/image';
+
+import { mockMypageUser, mockRecentlyViewedProducts } from '@/mocks/mypage';
+
+const FALLBACK_PROFILE_IMAGE = '/images/mock/profile.jpg';
+
+export function MypageSummaryPanel() {
+  return (
+    <aside className="space-y-12">
+      <section className="rounded-lg border border-gray-200 bg-white">
+        <div className="flex items-center justify-between px-6 pt-6">
+          <h2 className="text-lg font-bold text-gray-900">내 정보</h2>
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 text-sm font-medium text-gray-500"
+          >
+            수정하기
+            <ChevronRight className="size-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="flex items-center gap-4 px-6 py-6">
+          <div className="bg-primary-50 relative size-16 overflow-hidden rounded-full">
+            <Image
+              src={mockMypageUser.profileImage ?? FALLBACK_PROFILE_IMAGE}
+              alt={`${mockMypageUser.name} 프로필`}
+              fill
+              sizes="64px"
+              className="object-cover"
+            />
+          </div>
+          <div>
+            <p className="text-lg font-bold text-gray-900">
+              {mockMypageUser.name} 님
+            </p>
+            <p className="mt-1 text-sm text-gray-500">{mockMypageUser.email}</p>
+            <p className="mt-1 text-sm text-gray-500">{mockMypageUser.phone}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-gray-200 bg-white p-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-bold text-gray-900">보유 쿠폰</h2>
+        </div>
+
+        <div className="mt-5 rounded-md border border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-center">
+          <div className="mx-auto flex size-10 items-center justify-center rounded-full bg-white text-gray-400">
+            <Ticket className="size-5" aria-hidden="true" />
+          </div>
+          <p className="mt-3 text-sm font-semibold text-gray-700">
+            쿠폰 기능은 추후 추가 예정입니다.
+          </p>
+          <p className="mt-2 text-xs leading-5 text-gray-500">
+            보유 쿠폰과 쿠폰함은 쿠폰 API 연동 후 제공됩니다.
+          </p>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-gray-200 bg-white p-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-bold text-gray-900">최근 본 상품</h2>
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 text-sm font-medium text-gray-500"
+          >
+            전체보기
+            <ChevronRight className="size-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="mt-5 grid grid-cols-4 gap-3">
+          {mockRecentlyViewedProducts.map((product) => (
+            <div key={product.id}>
+              <div className="relative aspect-square overflow-hidden rounded-md bg-gray-100">
+                <Image
+                  src={product.imageUrl}
+                  alt={product.name}
+                  fill
+                  sizes="72px"
+                  className="object-cover"
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </aside>
+  );
+}

--- a/src/components/consumer/mypage/index.ts
+++ b/src/components/consumer/mypage/index.ts
@@ -1,0 +1,3 @@
+export { MypageReservationList } from './MypageReservationList';
+export { MypageSidebar } from './MypageSidebar';
+export { MypageSummaryPanel } from './MypageSummaryPanel';

--- a/src/mocks/mypage.ts
+++ b/src/mocks/mypage.ts
@@ -62,7 +62,11 @@ function formatPickupTime(value: string) {
 function findProductByOrder(
   order: OrderListItemResponse,
   index: number
-): ProductListItemResponse {
+): ProductListItemResponse | null {
+  if (mockProducts.length === 0) {
+    return null;
+  }
+
   return (
     mockProducts.find((product) => product.storeName === order.storeName) ??
     mockProducts[index % mockProducts.length]
@@ -71,24 +75,29 @@ function findProductByOrder(
 
 export const mockMypageUser = mockUser;
 
-export const mockMypageReservations: MockMypageReservation[] = mockOrders.map(
-  (order, index) => {
+export const mockMypageReservations: MockMypageReservation[] =
+  mockOrders.flatMap((order, index) => {
     const product = findProductByOrder(order, index);
 
-    return {
-      id: order.id,
-      orderNumber: order.storeOrderNumber ?? order.orderNumber,
-      storeName: order.storeName,
-      productName: product.name,
-      imageUrl: product.image ?? '/images/products/bread.jpg',
-      pickupDate: formatPickupDate(order.pickupAt),
-      pickupTime: formatPickupTime(order.pickupAt),
-      quantity: 1,
-      price: order.paymentAmount,
-      status: order.status,
-    };
-  }
-);
+    if (!product) {
+      return [];
+    }
+
+    return [
+      {
+        id: order.id,
+        orderNumber: order.storeOrderNumber ?? order.orderNumber,
+        storeName: order.storeName,
+        productName: product.name,
+        imageUrl: product.image ?? '/images/products/bread.jpg',
+        pickupDate: formatPickupDate(order.pickupAt),
+        pickupTime: formatPickupTime(order.pickupAt),
+        quantity: 1,
+        price: order.paymentAmount,
+        status: order.status,
+      },
+    ];
+  });
 
 export const mockRecentlyViewedProducts = mockProducts
   .slice(0, 4)

--- a/src/mocks/mypage.ts
+++ b/src/mocks/mypage.ts
@@ -29,6 +29,7 @@ function formatPickupDate(value: string) {
   }
 
   return new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
@@ -46,11 +47,13 @@ function formatPickupTime(value: string) {
   }
 
   const start = new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
     hour: '2-digit',
     minute: '2-digit',
     hour12: false,
   }).format(date);
   const end = new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
     hour: '2-digit',
     minute: '2-digit',
     hour12: false,

--- a/src/mocks/mypage.ts
+++ b/src/mocks/mypage.ts
@@ -1,0 +1,99 @@
+import type {
+  OrderListItemResponse,
+  OrderStatusParam,
+} from '@/contracts/order';
+import type { ProductListItemResponse } from '@/contracts/product';
+
+import { mockOrders } from './orders';
+import { mockProducts } from './products';
+import { mockUser } from './users';
+
+export interface MockMypageReservation {
+  id: string;
+  orderNumber: string;
+  storeName: string;
+  productName: string;
+  imageUrl: string;
+  pickupDate: string;
+  pickupTime: string;
+  quantity: number;
+  price: number;
+  status: OrderStatusParam;
+}
+
+function formatPickupDate(value: string) {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    weekday: 'short',
+  })
+    .format(date)
+    .replace(/\.$/, '');
+}
+
+function formatPickupTime(value: string) {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  const start = new Intl.DateTimeFormat('ko-KR', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(date);
+  const end = new Intl.DateTimeFormat('ko-KR', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date(date.getTime() + 60 * 60 * 1000));
+
+  return `${start} ~ ${end}`;
+}
+
+function findProductByOrder(
+  order: OrderListItemResponse,
+  index: number
+): ProductListItemResponse {
+  return (
+    mockProducts.find((product) => product.storeName === order.storeName) ??
+    mockProducts[index % mockProducts.length]
+  );
+}
+
+export const mockMypageUser = mockUser;
+
+export const mockMypageReservations: MockMypageReservation[] = mockOrders.map(
+  (order, index) => {
+    const product = findProductByOrder(order, index);
+
+    return {
+      id: order.id,
+      orderNumber: order.storeOrderNumber ?? order.orderNumber,
+      storeName: order.storeName,
+      productName: product.name,
+      imageUrl: product.image ?? '/images/products/bread.jpg',
+      pickupDate: formatPickupDate(order.pickupAt),
+      pickupTime: formatPickupTime(order.pickupAt),
+      quantity: 1,
+      price: order.paymentAmount,
+      status: order.status,
+    };
+  }
+);
+
+export const mockRecentlyViewedProducts = mockProducts
+  .slice(0, 4)
+  .map((product) => ({
+    id: product.id,
+    name: product.name,
+    imageUrl: product.image ?? '/images/products/bread.jpg',
+  }));

--- a/src/mocks/mypage.ts
+++ b/src/mocks/mypage.ts
@@ -18,7 +18,7 @@ export interface MockMypageReservation {
   pickupTime: string;
   quantity: number;
   price: number;
-  status: OrderStatusParam;
+  status: Exclude<OrderStatusParam, 'payment_pending'>;
 }
 
 function formatPickupDate(value: string) {
@@ -77,6 +77,10 @@ export const mockMypageUser = mockUser;
 
 export const mockMypageReservations: MockMypageReservation[] =
   mockOrders.flatMap((order, index) => {
+    if (order.status === 'payment_pending') {
+      return [];
+    }
+
     const product = findProductByOrder(order, index);
 
     if (!product) {
@@ -86,7 +90,7 @@ export const mockMypageReservations: MockMypageReservation[] =
     return [
       {
         id: order.id,
-        orderNumber: order.storeOrderNumber ?? order.orderNumber,
+        orderNumber: order.orderNumber,
         storeName: order.storeName,
         productName: product.name,
         imageUrl: product.image ?? '/images/products/bread.jpg',

--- a/src/mocks/orders.ts
+++ b/src/mocks/orders.ts
@@ -60,6 +60,22 @@ export const mockOrders: OrderListItemResponse[] = [
     createdAt: '2026-04-29T10:10:00.000Z',
     updatedAt: '2026-04-29T10:10:00.000Z',
   },
+  {
+    id: 'order_3',
+    orderNumber: 'PM20260429E1F2A3B4C5',
+    storeId: 'store_3',
+    storeName: '든든도시락 역삼점',
+    totalAmount: 11000,
+    discountAmount: 3300,
+    paymentAmount: 7700,
+    status: 'completed',
+    pickupAt: '2026-04-28T13:00:00.000Z',
+    pickupServiceDate: '2026-04-28',
+    storeOrderNumber: '20260428-0000003',
+    pickupNumber: 'B-03',
+    createdAt: '2026-04-28T10:30:00.000Z',
+    updatedAt: '2026-04-28T13:05:00.000Z',
+  },
 ];
 
 export const mockOrderDetail: OrderDetailResponse = {


### PR DESCRIPTION
## 📌 작업 내용

- 소비자 마이페이지의 기본 화면 레이아웃을 구현했습니다.
- 좌측 사이드바, 내 예약 목록 영역, 우측 요약 패널을 배치했습니다.
- 추후 예약 목록 API 연동 및 상세 기능을 붙일 수 있도록 컴포넌트 단위로 구조를 분리했습니다.

## 🔧 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 📂 주요 변경 파일

- `src/app/(consumer)/mypage/page.tsx`
- `src/components/consumer/mypage/MypageSidebar.tsx`
- `src/components/consumer/mypage/MypageReservationList.tsx`
- `src/components/consumer/mypage/MypageReservationCard.tsx`
- `src/components/consumer/mypage/MypageSummaryPanel.tsx`
- `src/components/consumer/mypage/index.ts`
- `src/mocks/mypage.ts`

## 🧪 테스트 방법

- `/mypage` 접속
- 좌측 마이페이지 사이드바가 표시되는지 확인
- 내 예약 카드 목록이 3개씩 자연스럽게 배치되는지 확인
- 예약 상태 탭 UI가 표시되는지 확인
- 우측 내 정보/쿠폰/최근 본 상품 영역이 표시되는지 확인

## 📸 스크린샷 (선택)

- 마이페이지 레이아웃 화면 캡처 첨부 예정

## 🔗 관련 이슈

- close #93 

## 📝 참고 사항

- 이번 이슈는 마이페이지 기본 레이아웃 구현 범위입니다.
- 예약 목록 API 연동, 예약 상세보기, 픽업 코드 보기, 쿠폰 기능은 후속 이슈에서 진행 예정입니다.
- 쿠폰 영역은 아직 기능이 없어 “추후 추가 예정” 안내 문구로 처리했습니다.
