### PR TITLE
feat: 결제 후 결과 화면 이동 추가

### DIFF
--- a/src/app/(consumer)/order/complete/page.tsx
+++ b/src/app/(consumer)/order/complete/page.tsx
@@ -1,0 +1,64 @@
+import Link from 'next/link';
+
+import { Footer, Header } from '@/components/common';
+
+interface OrderCompletePageProps {
+  searchParams: Promise<{ orderNumber?: string }>;
+}
+
+export default async function OrderCompletePage({
+  searchParams,
+}: OrderCompletePageProps) {
+  const { orderNumber } = await searchParams;
+
+  return (
+    <div className="bg-white">
+      <Header user={null} logoHref="/" />
+
+      <main className="flex min-h-[calc(100vh-160px)] items-center justify-center bg-white px-6 py-20">
+        <section className="w-full max-w-lg rounded-lg border border-gray-200 bg-white px-8 py-12 text-center shadow-sm">
+          <div
+            className="bg-primary-50 text-primary-500 mx-auto flex size-16 items-center justify-center rounded-full text-3xl font-black"
+            aria-hidden="true"
+          >
+            ✓
+          </div>
+
+          <h1 className="mt-8 text-3xl font-bold text-gray-900">
+            결제가 완료되었습니다
+          </h1>
+          <p className="mt-4 text-sm leading-6 text-gray-500">
+            예약이 정상적으로 확정되었습니다. 픽업 시간에 맞춰 매장을 방문해
+            주세요.
+          </p>
+
+          {orderNumber ? (
+            <dl className="mt-8 rounded-md bg-gray-50 px-5 py-4 text-sm">
+              <div className="flex items-center justify-between gap-4">
+                <dt className="font-medium text-gray-500">주문번호</dt>
+                <dd className="font-semibold text-gray-900">{orderNumber}</dd>
+              </div>
+            </dl>
+          ) : null}
+
+          <div className="mt-8 grid gap-3 sm:grid-cols-2">
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center rounded-sm border border-gray-300 px-4 py-3 font-medium text-gray-900 transition hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            >
+              홈으로
+            </Link>
+            <Link
+              href="/mypage"
+              className="bg-primary-500 hover:bg-primary-600 inline-flex items-center justify-center rounded-sm border border-transparent px-4 py-3 font-medium text-white transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            >
+              내 예약 보기
+            </Link>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/(consumer)/order/fail/page.tsx
+++ b/src/app/(consumer)/order/fail/page.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link';
+
+import { Footer, Header } from '@/components/common';
+
+interface OrderFailPageProps {
+  searchParams: Promise<{ reason?: string }>;
+}
+
+function getFailMessage(reason?: string) {
+  if (reason === 'payment_cancelled') {
+    return '결제가 취소되었습니다. 주문/결제 화면에서 다시 시도해 주세요.';
+  }
+
+  return '결제 처리 중 문제가 발생했습니다. 주문/결제 화면에서 다시 시도해 주세요.';
+}
+
+export default async function OrderFailPage({
+  searchParams,
+}: OrderFailPageProps) {
+  const { reason } = await searchParams;
+
+  return (
+    <div className="bg-white">
+      <Header user={null} logoHref="/" />
+
+      <main className="flex min-h-[calc(100vh-160px)] items-center justify-center bg-white px-6 py-10">
+        <section className="w-full max-w-lg rounded-lg border border-gray-200 bg-white px-8 py-9 text-center shadow-sm">
+          <div
+            className="mx-auto flex size-16 items-center justify-center rounded-full bg-red-50 text-3xl font-black text-red-500"
+            aria-hidden="true"
+          >
+            !
+          </div>
+
+          <h1 className="mt-6 text-3xl font-bold text-gray-900">
+            결제를 완료하지 못했습니다
+          </h1>
+          <p className="mt-4 text-sm leading-6 text-gray-500">
+            {getFailMessage(reason)}
+          </p>
+
+          <div className="mt-6 grid gap-3 sm:grid-cols-2">
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center rounded-sm border border-gray-300 px-4 py-3 font-medium text-gray-900 transition hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            >
+              홈으로
+            </Link>
+            <Link
+              href="/mypage"
+              className="bg-primary-500 hover:bg-primary-600 inline-flex items-center justify-center rounded-sm border border-transparent px-4 py-3 font-medium text-white transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            >
+              내 예약 보기
+            </Link>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/payment/toss-checkout/page.tsx
+++ b/src/app/payment/toss-checkout/page.tsx
@@ -4,7 +4,7 @@ import { ANONYMOUS, loadTossPayments } from '@tosspayments/tosspayments-sdk';
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useEffect } from 'react';
 
-function TossCheckoutInner() {
+function TossCheckoutContent() {
   const searchParams = useSearchParams();
 
   useEffect(() => {
@@ -48,8 +48,20 @@ function TossCheckoutInner() {
 
 export default function TossCheckoutPage() {
   return (
-    <Suspense>
-      <TossCheckoutInner />
+    <Suspense
+      fallback={
+        <main className="flex min-h-screen items-center justify-center bg-white px-6">
+          <p
+            role="status"
+            aria-live="polite"
+            className="text-sm font-medium text-gray-500"
+          >
+            결제창을 준비하는 중입니다.
+          </p>
+        </main>
+      }
+    >
+      <TossCheckoutContent />
     </Suspense>
   );
 }

--- a/src/hooks/payments/usePayment.test.ts
+++ b/src/hooks/payments/usePayment.test.ts
@@ -174,6 +174,66 @@ describe('usePayment', () => {
     );
   });
 
+  it('success:true 메시지에 orderNumber가 없으면 payment_failed reject', async () => {
+    const popup = makePopup();
+    vi.stubGlobal('open', vi.fn().mockReturnValue(popup));
+    const { result } = renderHook(() => usePayment(), {
+      wrapper: createWrapper(),
+    });
+
+    const promise = result.current.openPayment({
+      orderNumber: 'PM2026TEST',
+      orderName: '크루아상 2개',
+    });
+
+    await waitFor(() => expect(window.open).toHaveBeenCalled());
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: window.location.origin,
+          source: popup,
+          data: { success: true },
+        })
+      );
+    });
+
+    await expect(promise).rejects.toThrow('payment_failed');
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      '/order/fail?reason=payment_failed'
+    );
+  });
+
+  it('success:true 메시지의 orderNumber가 요청값과 다르면 payment_failed reject', async () => {
+    const popup = makePopup();
+    vi.stubGlobal('open', vi.fn().mockReturnValue(popup));
+    const { result } = renderHook(() => usePayment(), {
+      wrapper: createWrapper(),
+    });
+
+    const promise = result.current.openPayment({
+      orderNumber: 'PM2026TEST',
+      orderName: '크루아상 2개',
+    });
+
+    await waitFor(() => expect(window.open).toHaveBeenCalled());
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: window.location.origin,
+          source: popup,
+          data: { success: true, orderNumber: 'PM2026OTHER' },
+        })
+      );
+    });
+
+    await expect(promise).rejects.toThrow('payment_failed');
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      '/order/fail?reason=payment_failed'
+    );
+  });
+
   it('다른 origin 메시지는 무시 → 이후 정상 메시지 처리', async () => {
     const popup = makePopup();
     vi.stubGlobal('open', vi.fn().mockReturnValue(popup));

--- a/src/hooks/payments/usePayment.test.ts
+++ b/src/hooks/payments/usePayment.test.ts
@@ -12,6 +12,13 @@ vi.mock('@/api/payments/paymentApi', () => ({
 }));
 
 const mockInvalidateQueries = vi.fn().mockResolvedValue(undefined);
+const mockRouterPush = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+  }),
+}));
 
 vi.mock('@tanstack/react-query', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
@@ -84,6 +91,9 @@ describe('usePayment', () => {
     });
 
     await expect(promise).resolves.toEqual({ orderNumber: 'PM2026TEST' });
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      '/order/complete?orderNumber=PM2026TEST'
+    );
   });
 
   it('window.open 반환값이 null → 팝업 차단 에러 reject', async () => {
@@ -129,6 +139,9 @@ describe('usePayment', () => {
     expect(mockInvalidateQueries).toHaveBeenCalledWith({
       queryKey: ['orders'],
     });
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      '/order/complete?orderNumber=PM2026TEST'
+    );
   });
 
   it('success:false 메시지 수신 시 reject', async () => {
@@ -156,6 +169,9 @@ describe('usePayment', () => {
     });
 
     await expect(promise).rejects.toThrow('payment_failed');
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      '/order/fail?reason=payment_failed'
+    );
   });
 
   it('다른 origin 메시지는 무시 → 이후 정상 메시지 처리', async () => {
@@ -212,5 +228,8 @@ describe('usePayment', () => {
     (popup as unknown as { closed: boolean }).closed = true;
 
     await expect(promise).rejects.toThrow('payment_cancelled');
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      '/order/fail?reason=payment_cancelled'
+    );
   }, 3000);
 });

--- a/src/hooks/payments/usePayment.ts
+++ b/src/hooks/payments/usePayment.ts
@@ -49,7 +49,10 @@ export function usePayment() {
           if (event.data?.success === true) {
             const msgOrderNumber = (event.data as { orderNumber?: unknown })
               .orderNumber;
-            if (typeof msgOrderNumber !== 'string' || !msgOrderNumber) {
+            if (
+              typeof msgOrderNumber !== 'string' ||
+              msgOrderNumber !== orderNumber
+            ) {
               router.push('/order/fail?reason=payment_failed');
               reject(new Error('payment_failed'));
               return;

--- a/src/hooks/payments/usePayment.ts
+++ b/src/hooks/payments/usePayment.ts
@@ -1,11 +1,13 @@
 'use client';
 
 import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 import { useRef, useState } from 'react';
 
 import { paymentApi } from '@/api/payments/paymentApi';
 
 export function usePayment() {
+  const router = useRouter();
   const queryClient = useQueryClient();
   const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -48,12 +50,17 @@ export function usePayment() {
             const msgOrderNumber = (event.data as { orderNumber?: unknown })
               .orderNumber;
             if (typeof msgOrderNumber !== 'string' || !msgOrderNumber) {
+              router.push('/order/fail?reason=payment_failed');
               reject(new Error('payment_failed'));
               return;
             }
             void queryClient.invalidateQueries({ queryKey: ['orders'] });
+            router.push(
+              `/order/complete?orderNumber=${encodeURIComponent(msgOrderNumber)}`
+            );
             resolve({ orderNumber: msgOrderNumber });
           } else {
+            router.push('/order/fail?reason=payment_failed');
             reject(new Error('payment_failed'));
           }
         };
@@ -61,6 +68,7 @@ export function usePayment() {
         const timer = setInterval(() => {
           if (popup.closed) {
             cleanup();
+            router.push('/order/fail?reason=payment_cancelled');
             reject(new Error('payment_cancelled'));
           }
         }, 500);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from 'next/server';
 
 import { createProxyClient } from '@/lib/supabase/proxy';
 
-const CONSUMER_PROTECTED = ['/mypage'];
+const CONSUMER_PROTECTED = ['/order', '/payment', '/mypage'];
 const SELLER_PROTECTED = [
   '/seller/register',
   '/seller/pending',

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from 'next/server';
 
 import { createProxyClient } from '@/lib/supabase/proxy';
 
-const CONSUMER_PROTECTED = ['/order', '/payment', '/mypage'];
+const CONSUMER_PROTECTED = ['/mypage'];
 const SELLER_PROTECTED = [
   '/seller/register',
   '/seller/pending',


### PR DESCRIPTION
## 📌 작업 내용

- 결제 팝업 처리 이후 사용자가 확인할 수 있는 결제 결과 화면을 추가했습니다.
- `usePayment`에서 토스페이먼츠 팝업 결과 메시지를 받은 뒤 성공/실패 결과 화면으로 이동하도록 연결했습니다.
- 기존 `/payment/success`, `/payment/fail` 콜백 라우트는 건드리지 않고, 부모 창에서 보여줄 결과 화면만 분리했습니다.

## 🔧 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📂 주요 변경 파일

- `src/hooks/payments/usePayment.ts`
- `src/hooks/payments/usePayment.test.ts`
- `src/app/(consumer)/order/complete/page.tsx`
- `src/app/(consumer)/order/fail/page.tsx`
- `src/app/payment/toss-checkout/page.tsx`

## 🧪 테스트 방법

- `npm run lint -- src/hooks/payments/usePayment.ts src/hooks/payments/usePayment.test.ts src/app/'(consumer)'/order/complete/page.tsx src/app/'(consumer)'/order/fail/page.tsx src/app/payment/toss-checkout/page.tsx`
- `npm run test:run -- src/hooks/payments/usePayment.test.ts`
- `npm run build`

## 📌 참고 사항

- `/payment/success`, `/payment/fail`은 토스페이먼츠 팝업 콜백 라우트로 유지했습니다.
- 사용자가 실제로 보는 결제 결과 화면은 `/order/complete`, `/order/fail`로 분리했습니다.
- `/payment/toss-checkout`은 `useSearchParams` 사용으로 인한 Next.js 빌드 오류를 방지하기 위해 `Suspense` 경계만 추가했습니다.

## 🔗 관련 이슈

- close #114 
