### PR TITLE
feat: 마이페이지 내 정보 패널 API 연동

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,30 @@
 import type { NextConfig } from 'next';
 
+function getSupabaseImageRemotePatterns(): NonNullable<
+  NextConfig['images']
+>['remotePatterns'] {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+  if (!supabaseUrl) {
+    return [];
+  }
+
+  try {
+    return [
+      {
+        protocol: 'https',
+        hostname: new URL(supabaseUrl).hostname,
+      },
+    ];
+  } catch {
+    return [];
+  }
+}
+
 const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: getSupabaseImageRemotePatterns(),
+  },
   reactCompiler: true,
 };
 

--- a/src/components/consumer/mypage/MypageSummaryPanel.tsx
+++ b/src/components/consumer/mypage/MypageSummaryPanel.tsx
@@ -8,10 +8,22 @@ import { mockRecentlyViewedProducts } from '@/mocks/mypage';
 
 const FALLBACK_PROFILE_IMAGE = '/images/mock/profile.jpg';
 
+function getSafeProfileImage(profileImage?: string) {
+  if (!profileImage) {
+    return FALLBACK_PROFILE_IMAGE;
+  }
+
+  if (profileImage.startsWith('/')) {
+    return profileImage;
+  }
+
+  return FALLBACK_PROFILE_IMAGE;
+}
+
 export function MypageSummaryPanel() {
   const { data: user, isError, isLoading } = useMe();
   const userName = user?.name ?? '사용자';
-  const profileImage = user?.profileImage || FALLBACK_PROFILE_IMAGE;
+  const profileImage = getSafeProfileImage(user?.profileImage);
 
   return (
     <aside className="space-y-12">

--- a/src/components/consumer/mypage/MypageSummaryPanel.tsx
+++ b/src/components/consumer/mypage/MypageSummaryPanel.tsx
@@ -8,12 +8,36 @@ import { mockRecentlyViewedProducts } from '@/mocks/mypage';
 
 const FALLBACK_PROFILE_IMAGE = '/images/mock/profile.jpg';
 
+function isSupabaseStorageImage(profileImage: string) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+  if (!supabaseUrl) {
+    return false;
+  }
+
+  try {
+    const imageUrl = new URL(profileImage);
+    const storageUrl = new URL(supabaseUrl);
+
+    return (
+      imageUrl.protocol === 'https:' &&
+      imageUrl.hostname === storageUrl.hostname
+    );
+  } catch {
+    return false;
+  }
+}
+
 function getSafeProfileImage(profileImage?: string) {
   if (!profileImage) {
     return FALLBACK_PROFILE_IMAGE;
   }
 
   if (profileImage.startsWith('/')) {
+    return profileImage;
+  }
+
+  if (isSupabaseStorageImage(profileImage)) {
     return profileImage;
   }
 

--- a/src/components/consumer/mypage/MypageSummaryPanel.tsx
+++ b/src/components/consumer/mypage/MypageSummaryPanel.tsx
@@ -1,11 +1,18 @@
+'use client';
+
 import { ChevronRight, Ticket } from 'lucide-react';
 import Image from 'next/image';
 
-import { mockMypageUser, mockRecentlyViewedProducts } from '@/mocks/mypage';
+import { useMe } from '@/hooks/users/useMe';
+import { mockRecentlyViewedProducts } from '@/mocks/mypage';
 
 const FALLBACK_PROFILE_IMAGE = '/images/mock/profile.jpg';
 
 export function MypageSummaryPanel() {
+  const { data: user, isError, isLoading } = useMe();
+  const userName = user?.name ?? '사용자';
+  const profileImage = user?.profileImage || FALLBACK_PROFILE_IMAGE;
+
   return (
     <aside className="space-y-12">
       <section className="rounded-lg border border-gray-200 bg-white">
@@ -22,22 +29,46 @@ export function MypageSummaryPanel() {
         </div>
 
         <div className="flex items-center gap-4 px-6 py-6">
-          <div className="bg-primary-50 relative size-16 overflow-hidden rounded-full">
-            <Image
-              src={mockMypageUser.profileImage ?? FALLBACK_PROFILE_IMAGE}
-              alt={`${mockMypageUser.name} 프로필`}
-              fill
-              sizes="64px"
-              className="object-cover"
-            />
-          </div>
-          <div>
-            <p className="text-lg font-bold text-gray-900">
-              {mockMypageUser.name} 님
+          {isLoading ? (
+            <p
+              role="status"
+              aria-live="polite"
+              className="text-sm font-medium text-gray-500"
+            >
+              내 정보를 불러오는 중입니다.
             </p>
-            <p className="mt-1 text-sm text-gray-500">{mockMypageUser.email}</p>
-            <p className="mt-1 text-sm text-gray-500">{mockMypageUser.phone}</p>
-          </div>
+          ) : null}
+
+          {isError ? (
+            <p
+              role="alert"
+              aria-live="assertive"
+              className="text-sm font-medium text-red-500"
+            >
+              내 정보를 불러오지 못했습니다.
+            </p>
+          ) : null}
+
+          {!isLoading && !isError && user ? (
+            <>
+              <div className="bg-primary-50 relative size-16 overflow-hidden rounded-full">
+                <Image
+                  src={profileImage}
+                  alt={`${userName} 프로필`}
+                  fill
+                  sizes="64px"
+                  className="object-cover"
+                />
+              </div>
+              <div>
+                <p className="text-lg font-bold text-gray-900">{userName} 님</p>
+                <p className="mt-1 text-sm text-gray-500">{user.email}</p>
+                <p className="mt-1 text-sm text-gray-500">
+                  {user.phone ?? '등록된 전화번호가 없습니다.'}
+                </p>
+              </div>
+            </>
+          ) : null}
         </div>
       </section>
 

--- a/src/mocks/mypage.ts
+++ b/src/mocks/mypage.ts
@@ -1,7 +1,4 @@
 import { mockProducts } from './products';
-import { mockUser } from './users';
-
-export const mockMypageUser = mockUser;
 
 export const mockRecentlyViewedProducts = mockProducts
   .slice(0, 4)


### PR DESCRIPTION
## 📌 작업 내용

- 마이페이지 우측 내 정보 패널을 실제 사용자 정보 API 기반으로 렌더링했습니다.
- 프로필 이미지, 이름, 이메일, 전화번호 표시 영역을 정리했습니다.
- 쿠폰 영역은 API 미구현 상태에 맞춰 추후 추가 예정 안내로 변경했습니다.

## 🔧 변경 사항

- [x] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 📂 주요 변경 파일

- `MypageSummaryPanel.tsx`

## 🧪 테스트 방법

- `/mypage` 접속
- 로그인 사용자 정보가 내 정보 패널에 표시되는지 확인
- 전화번호가 없을 때 fallback 문구가 표시되는지 확인
- 프로필 이미지가 없거나 허용되지 않은 외부 URL일 때 fallback 이미지가 표시되는지 확인
- 쿠폰 영역에 “추후 추가 예정” 안내가 표시되는지 확인

## 📸 스크린샷 (선택)

- 마이페이지 우측 내 정보 패널 화면 캡처 첨부

## 🔗 관련 이슈

- close #107

## 📝 참고 사항

- 수정하기 기능은 후속 이슈에서 연결 예정입니다.
- 쿠폰 기능은 쿠폰 API 확정 후 별도 이슈에서 구현 예정입니다.
