### PR TITLE
feat: 마이페이지 사이드바 구현

### DIFF
--- a/src/components/consumer/mypage/MypageSidebar.tsx
+++ b/src/components/consumer/mypage/MypageSidebar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   CalendarCheck,
   CircleHelp,
@@ -6,26 +8,33 @@ import {
   Settings,
   User,
 } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import type { ReactNode } from 'react';
 
-const menuItems = [
+interface SidebarItem {
+  label: string;
+  icon: ReactNode;
+  href?: string;
+}
+
+const menuItems: SidebarItem[] = [
   {
     label: '내 예약',
     icon: <CalendarCheck className="size-5" aria-hidden="true" />,
-    active: true,
+    href: '/mypage',
   },
   {
     label: '내 정보',
     icon: <User className="size-5" aria-hidden="true" />,
-    active: false,
   },
   {
     label: '설정',
     icon: <Settings className="size-5" aria-hidden="true" />,
-    active: false,
   },
 ];
 
-const supportItems = [
+const supportItems: SidebarItem[] = [
   {
     label: '자주 묻는 질문',
     icon: <CircleHelp className="size-5" aria-hidden="true" />,
@@ -40,6 +49,46 @@ const supportItems = [
   },
 ];
 
+function isActivePath(pathname: string, href: string) {
+  return pathname === href;
+}
+
+function getItemClassName(isActive: boolean, isDisabled: boolean) {
+  return [
+    'flex w-full items-center gap-3 rounded-md px-4 py-3 text-left text-base font-semibold transition focus-visible:ring-primary-500 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+    isActive ? 'bg-primary-50 text-primary-500' : '',
+    !isActive && !isDisabled ? 'text-gray-700 hover:bg-gray-50' : '',
+    isDisabled ? 'cursor-not-allowed text-gray-400' : '',
+  ].join(' ');
+}
+
+function SidebarMenuItem({ item }: { item: SidebarItem }) {
+  const pathname = usePathname();
+  const isActive = item.href ? isActivePath(pathname, item.href) : false;
+  const className = getItemClassName(isActive, !item.href);
+
+  if (item.href) {
+    return (
+      <Link
+        href={item.href}
+        aria-current={isActive ? 'page' : undefined}
+        className={className}
+      >
+        {item.icon}
+        <span>{item.label}</span>
+      </Link>
+    );
+  }
+
+  return (
+    <button type="button" disabled aria-disabled="true" className={className}>
+      {item.icon}
+      <span>{item.label}</span>
+      <span className="ml-auto text-xs font-medium text-gray-400">준비중</span>
+    </button>
+  );
+}
+
 export function MypageSidebar() {
   return (
     <aside className="hidden border-r border-gray-200 px-10 py-10 lg:block">
@@ -47,21 +96,7 @@ export function MypageSidebar() {
 
       <nav className="mt-6 space-y-2" aria-label="마이페이지 메뉴">
         {menuItems.map((item) => (
-          <button
-            key={item.label}
-            type="button"
-            disabled={!item.active}
-            className={[
-              'flex w-full items-center gap-3 rounded-md px-4 py-3 text-left text-base font-semibold disabled:cursor-not-allowed disabled:opacity-50',
-              item.active
-                ? 'bg-primary-50 text-primary-500'
-                : 'text-gray-700 hover:bg-gray-50',
-            ].join(' ')}
-            aria-current={item.active ? 'page' : undefined}
-          >
-            {item.icon}
-            {item.label}
-          </button>
+          <SidebarMenuItem key={item.label} item={item} />
         ))}
       </nav>
 
@@ -69,15 +104,7 @@ export function MypageSidebar() {
         <p className="text-base font-bold text-gray-900">고객센터</p>
         <nav className="mt-4 space-y-2" aria-label="고객센터 메뉴">
           {supportItems.map((item) => (
-            <button
-              key={item.label}
-              type="button"
-              disabled
-              className="flex w-full cursor-not-allowed items-center gap-3 rounded-md px-4 py-3 text-left text-base font-medium text-gray-700 opacity-50"
-            >
-              {item.icon}
-              {item.label}
-            </button>
+            <SidebarMenuItem key={item.label} item={item} />
           ))}
         </nav>
       </div>


### PR DESCRIPTION
## 📌 작업 내용

- 마이페이지 좌측 사이드바 레이아웃을 구현했습니다.
- 마이페이지 주요 메뉴와 고객센터 메뉴를 분리해 배치했습니다.
- 현재 페이지 메뉴가 시각적으로 구분되도록 활성 상태 스타일을 적용했습니다.

## 🔧 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 📂 주요 변경 파일

- `MypageSidebar.tsx`
- `page.tsx`

## 🧪 테스트 방법

- `/mypage` 접속
- 좌측 사이드바가 화면에 표시되는지 확인
- 내 예약 메뉴가 활성 상태로 표시되는지 확인
- 고객센터 메뉴와 일반 메뉴가 구분되어 보이는지 확인
- 작은 화면에서 레이아웃이 깨지지 않는지 확인

## 📸 스크린샷 (선택)

- x

## 🔗 관련 이슈

- close #108 

## 📝 참고 사항

- 내 정보, 설정, 고객센터 상세 이동은 후속 이슈에서 연결 예정입니다.
- 현재 PR은 마이페이지 사이드바 UI 구성에 집중했습니다.
