### PR TITLE
feat: 최근 본 상품 기능 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -23,13 +23,7 @@ function getSupabaseImageRemotePatterns(): NonNullable<
 
 const nextConfig: NextConfig = {
   images: {
-    remotePatterns: [
-      ...getSupabaseImageRemotePatterns(),
-      {
-        protocol: 'https',
-        hostname: '**',
-      },
-    ],
+    remotePatterns: getSupabaseImageRemotePatterns(),
   },
   reactCompiler: true,
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,7 +23,13 @@ function getSupabaseImageRemotePatterns(): NonNullable<
 
 const nextConfig: NextConfig = {
   images: {
-    remotePatterns: getSupabaseImageRemotePatterns(),
+    remotePatterns: [
+      ...getSupabaseImageRemotePatterns(),
+      {
+        protocol: 'https',
+        hostname: '**',
+      },
+    ],
   },
   reactCompiler: true,
 };

--- a/src/components/consumer/ProductDetailContainer.tsx
+++ b/src/components/consumer/ProductDetailContainer.tsx
@@ -8,6 +8,7 @@ import { ProductDetailInfo } from './ProductDetailInfo';
 import { ProductDetailTabs } from './ProductDetailTabs';
 import { ProductImageGallery } from './ProductImageGallery';
 import { ProductReservationPanel } from './ProductReservationPanel';
+import { RecentProductTracker } from './RecentProductTracker';
 
 interface ProductDetailContainerProps {
   productId: string;
@@ -96,6 +97,14 @@ export function ProductDetailContainer({
 
   return (
     <div className="bg-white">
+      <RecentProductTracker
+        product={{
+          id: product.id,
+          name: product.name,
+          imageUrl: product.image,
+        }}
+      />
+
       <ConsumerHeader />
 
       <main className="min-h-screen bg-white">

--- a/src/components/consumer/ProductDetailContainer.tsx
+++ b/src/components/consumer/ProductDetailContainer.tsx
@@ -98,11 +98,9 @@ export function ProductDetailContainer({
   return (
     <div className="bg-white">
       <RecentProductTracker
-        product={{
-          id: product.id,
-          name: product.name,
-          imageUrl: product.image,
-        }}
+        id={product.id}
+        name={product.name}
+        imageUrl={product.image}
       />
 
       <ConsumerHeader />

--- a/src/components/consumer/RecentProductTracker.tsx
+++ b/src/components/consumer/RecentProductTracker.tsx
@@ -6,13 +6,25 @@ import type { RecentProductInput } from '@/lib/recentProducts';
 import { addRecentProduct } from '@/lib/recentProducts';
 
 interface RecentProductTrackerProps {
-  product: RecentProductInput;
+  id: string;
+  name: string;
+  imageUrl?: string;
 }
 
-export function RecentProductTracker({ product }: RecentProductTrackerProps) {
+export function RecentProductTracker({
+  id,
+  name,
+  imageUrl,
+}: RecentProductTrackerProps) {
   useEffect(() => {
+    const product: RecentProductInput = {
+      id,
+      name,
+      imageUrl,
+    };
+
     addRecentProduct(product);
-  }, [product]);
+  }, [id, imageUrl, name]);
 
   return null;
 }

--- a/src/components/consumer/RecentProductTracker.tsx
+++ b/src/components/consumer/RecentProductTracker.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import type { RecentProductInput } from '@/lib/recentProducts';
+import { addRecentProduct } from '@/lib/recentProducts';
+
+interface RecentProductTrackerProps {
+  product: RecentProductInput;
+}
+
+export function RecentProductTracker({ product }: RecentProductTrackerProps) {
+  useEffect(() => {
+    addRecentProduct(product);
+  }, [product]);
+
+  return null;
+}

--- a/src/components/consumer/mypage/MypageSummaryPanel.tsx
+++ b/src/components/consumer/mypage/MypageSummaryPanel.tsx
@@ -2,11 +2,13 @@
 
 import { ChevronRight, Ticket } from 'lucide-react';
 import Image from 'next/image';
+import Link from 'next/link';
 
+import { useRecentProducts } from '@/hooks/products/useRecentProducts';
 import { useMe } from '@/hooks/users/useMe';
-import { mockRecentlyViewedProducts } from '@/mocks/mypage';
 
 const FALLBACK_PROFILE_IMAGE = '/images/mock/profile.jpg';
+const FALLBACK_RECENT_PRODUCT_IMAGE = '/images/products/noimage.png';
 
 function isSupabaseStorageImage(profileImage: string) {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -44,8 +46,21 @@ function getSafeProfileImage(profileImage?: string) {
   return FALLBACK_PROFILE_IMAGE;
 }
 
+function getSafeProductImage(imageUrl?: string) {
+  if (!imageUrl) {
+    return FALLBACK_RECENT_PRODUCT_IMAGE;
+  }
+
+  if (imageUrl.startsWith('/')) {
+    return imageUrl;
+  }
+
+  return FALLBACK_RECENT_PRODUCT_IMAGE;
+}
+
 export function MypageSummaryPanel() {
   const { data: user, isError, isLoading } = useMe();
+  const recentProducts = useRecentProducts().slice(0, 4);
   const userName = user?.name ?? '사용자';
   const profileImage = getSafeProfileImage(user?.profileImage);
 
@@ -133,27 +148,39 @@ export function MypageSummaryPanel() {
             type="button"
             disabled
             className="inline-flex cursor-not-allowed items-center gap-1 text-sm font-medium text-gray-400"
+            aria-disabled="true"
           >
             전체보기
             <ChevronRight className="size-4" aria-hidden="true" />
           </button>
         </div>
 
-        <div className="mt-5 grid grid-cols-4 gap-3">
-          {mockRecentlyViewedProducts.map((product) => (
-            <div key={product.id}>
-              <div className="relative aspect-square overflow-hidden rounded-md bg-gray-100">
-                <Image
-                  src={product.imageUrl}
-                  alt={product.name}
-                  fill
-                  sizes="72px"
-                  className="object-cover"
-                />
-              </div>
-            </div>
-          ))}
-        </div>
+        {recentProducts.length > 0 ? (
+          <div className="mt-5 grid grid-cols-4 gap-3">
+            {recentProducts.map((product) => (
+              <Link
+                key={product.id}
+                href={`/products/${product.id}`}
+                aria-label={`${product.name} 상품 상세 보기`}
+                className="focus-visible:ring-primary-500 rounded-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              >
+                <div className="relative aspect-square overflow-hidden rounded-md bg-gray-100">
+                  <Image
+                    src={getSafeProductImage(product.imageUrl)}
+                    alt={product.name}
+                    fill
+                    sizes="72px"
+                    className="object-cover"
+                  />
+                </div>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <p className="mt-5 rounded-md border border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-center text-sm font-medium text-gray-500">
+            최근 본 상품이 없습니다.
+          </p>
+        )}
       </section>
     </aside>
   );

--- a/src/components/consumer/mypage/MypageSummaryPanel.tsx
+++ b/src/components/consumer/mypage/MypageSummaryPanel.tsx
@@ -55,6 +55,16 @@ function getSafeProductImage(imageUrl?: string) {
     return imageUrl;
   }
 
+  try {
+    const url = new URL(imageUrl);
+
+    if (url.protocol === 'https:') {
+      return imageUrl;
+    }
+  } catch {
+    return FALLBACK_RECENT_PRODUCT_IMAGE;
+  }
+
   return FALLBACK_RECENT_PRODUCT_IMAGE;
 }
 

--- a/src/components/consumer/mypage/MypageSummaryPanel.tsx
+++ b/src/components/consumer/mypage/MypageSummaryPanel.tsx
@@ -55,16 +55,6 @@ function getSafeProductImage(imageUrl?: string) {
     return imageUrl;
   }
 
-  try {
-    const url = new URL(imageUrl);
-
-    if (url.protocol === 'https:') {
-      return imageUrl;
-    }
-  } catch {
-    return FALLBACK_RECENT_PRODUCT_IMAGE;
-  }
-
   return FALLBACK_RECENT_PRODUCT_IMAGE;
 }
 

--- a/src/hooks/products/useRecentProducts.ts
+++ b/src/hooks/products/useRecentProducts.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+import {
+  getRecentProductsRawSnapshot,
+  getRecentProductsServerSnapshot,
+  parseRecentProducts,
+  subscribeRecentProducts,
+} from '@/lib/recentProducts';
+
+export function useRecentProducts() {
+  const recentProductsSnapshot = useSyncExternalStore(
+    subscribeRecentProducts,
+    getRecentProductsRawSnapshot,
+    getRecentProductsServerSnapshot
+  );
+
+  return parseRecentProducts(recentProductsSnapshot);
+}

--- a/src/lib/recentProducts.ts
+++ b/src/lib/recentProducts.ts
@@ -1,0 +1,105 @@
+export interface RecentProduct {
+  id: string;
+  name: string;
+  imageUrl?: string;
+  viewedAt: string;
+}
+
+export type RecentProductInput = Pick<
+  RecentProduct,
+  'id' | 'name' | 'imageUrl'
+>;
+
+export const RECENT_PRODUCTS_STORAGE_KEY = 'pickma:recent-products';
+export const RECENT_PRODUCTS_EVENT = 'pickma:recent-products-change';
+
+const MAX_RECENT_PRODUCTS = 10;
+const EMPTY_RECENT_PRODUCTS = '[]';
+
+export function parseRecentProducts(value: string): RecentProduct[] {
+  try {
+    const parsed = JSON.parse(value);
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter(isRecentProduct);
+  } catch {
+    return [];
+  }
+}
+
+export function getRecentProductsRawSnapshot() {
+  if (typeof window === 'undefined') {
+    return EMPTY_RECENT_PRODUCTS;
+  }
+
+  return (
+    window.localStorage.getItem(RECENT_PRODUCTS_STORAGE_KEY) ??
+    EMPTY_RECENT_PRODUCTS
+  );
+}
+
+export function getRecentProductsServerSnapshot() {
+  return EMPTY_RECENT_PRODUCTS;
+}
+
+export function subscribeRecentProducts(listener: () => void) {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === RECENT_PRODUCTS_STORAGE_KEY) {
+      listener();
+    }
+  };
+
+  window.addEventListener(RECENT_PRODUCTS_EVENT, listener);
+  window.addEventListener('storage', handleStorage);
+
+  return () => {
+    window.removeEventListener(RECENT_PRODUCTS_EVENT, listener);
+    window.removeEventListener('storage', handleStorage);
+  };
+}
+
+export function addRecentProduct(product: RecentProductInput) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const recentProducts = parseRecentProducts(getRecentProductsRawSnapshot());
+  const nextProduct: RecentProduct = {
+    ...product,
+    viewedAt: new Date().toISOString(),
+  };
+  const nextProducts = [
+    nextProduct,
+    ...recentProducts.filter(
+      (recentProduct) => recentProduct.id !== product.id
+    ),
+  ].slice(0, MAX_RECENT_PRODUCTS);
+
+  window.localStorage.setItem(
+    RECENT_PRODUCTS_STORAGE_KEY,
+    JSON.stringify(nextProducts)
+  );
+  window.dispatchEvent(new Event(RECENT_PRODUCTS_EVENT));
+}
+
+function isRecentProduct(value: unknown): value is RecentProduct {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const product = value as Partial<RecentProduct>;
+  return (
+    typeof product.id === 'string' &&
+    typeof product.name === 'string' &&
+    typeof product.viewedAt === 'string' &&
+    (typeof product.imageUrl === 'string' ||
+      typeof product.imageUrl === 'undefined')
+  );
+}

--- a/src/lib/recentProducts.ts
+++ b/src/lib/recentProducts.ts
@@ -35,10 +35,14 @@ export function getRecentProductsRawSnapshot() {
     return EMPTY_RECENT_PRODUCTS;
   }
 
-  return (
-    window.localStorage.getItem(RECENT_PRODUCTS_STORAGE_KEY) ??
-    EMPTY_RECENT_PRODUCTS
-  );
+  try {
+    return (
+      window.localStorage.getItem(RECENT_PRODUCTS_STORAGE_KEY) ??
+      EMPTY_RECENT_PRODUCTS
+    );
+  } catch {
+    return EMPTY_RECENT_PRODUCTS;
+  }
 }
 
 export function getRecentProductsServerSnapshot() {
@@ -82,11 +86,15 @@ export function addRecentProduct(product: RecentProductInput) {
     ),
   ].slice(0, MAX_RECENT_PRODUCTS);
 
-  window.localStorage.setItem(
-    RECENT_PRODUCTS_STORAGE_KEY,
-    JSON.stringify(nextProducts)
-  );
-  window.dispatchEvent(new Event(RECENT_PRODUCTS_EVENT));
+  try {
+    window.localStorage.setItem(
+      RECENT_PRODUCTS_STORAGE_KEY,
+      JSON.stringify(nextProducts)
+    );
+    window.dispatchEvent(new Event(RECENT_PRODUCTS_EVENT));
+  } catch {
+    return;
+  }
 }
 
 function isRecentProduct(value: unknown): value is RecentProduct {

--- a/src/mocks/mypage.ts
+++ b/src/mocks/mypage.ts
@@ -1,9 +1,0 @@
-import { mockProducts } from './products';
-
-export const mockRecentlyViewedProducts = mockProducts
-  .slice(0, 4)
-  .map((product) => ({
-    id: product.id,
-    name: product.name,
-    imageUrl: product.image ?? '/images/products/bread.jpg',
-  }));


### PR DESCRIPTION
## 📌 작업 내용

- 상품 상세 페이지 진입 시 최근 본 상품을 로컬에 저장하도록 구현했습니다.
- 마이페이지 우측 패널에 최근 본 상품 목록을 표시했습니다.
- 최근 본 상품이 없을 때 빈 상태 UI를 추가했습니다.

## 🔧 변경 사항

- [x] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 📂 주요 변경 파일

- `RecentProductTracker.tsx`
- `useRecentProducts.ts`
- `recentProducts.ts`
- `MypageSummaryPanel.tsx`
- `products/[productId]/page.tsx`

## 🧪 테스트 방법

- 상품 상세 페이지 접속
- `/mypage` 접속 후 최근 본 상품 영역에 상품이 표시되는지 확인
- 여러 상품 상세 페이지를 방문했을 때 최근 본 상품 순서가 갱신되는지 확인
- 같은 상품을 다시 방문했을 때 중복 없이 최신 순서로 올라오는지 확인
- 최근 본 상품 이미지가 없거나 외부 URL일 때 fallback 이미지가 표시되는지 확인

## 📸 스크린샷 (선택)

- x

## 🔗 관련 이슈

- close #109 

## 📝 참고 사항

- 최근 본 상품은 현재 `localStorage` 기반으로 관리합니다.
- 최근 본 상품 전체보기 기능은 후속 이슈에서 연결 예정입니다.
- 외부 이미지 URL은 현재 허용하지 않고 fallback 이미지로 처리합니다.
