### PR TITLE
feat: 판매자 페이지 헤더 드롭다운 메뉴 구현

### DIFF
--- a/src/app/(seller)/seller/layout.tsx
+++ b/src/app/(seller)/seller/layout.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+import { authApi } from '@/api/auth/authApi';
 import { useMe } from '@/hooks/users/useMe';
 import { AuthModal } from '@/components/auth/AuthModal';
 import { useAuthModal } from '@/components/auth/useAuthModal';
@@ -15,6 +19,14 @@ export default function SellerLayout({
 }) {
   const { data: user } = useMe();
   const { openAuthModal } = useAuthModal();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const handleSignOut = async () => {
+    await authApi.signOut();
+    await queryClient.invalidateQueries({ queryKey: ['me'] });
+    router.refresh();
+  };
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -23,7 +35,21 @@ export default function SellerLayout({
         logoHref="/seller"
         menuItems={
           user
-            ? []
+            ? [
+                {
+                  label: '소비자 센터',
+                  type: 'link',
+                  href: '/',
+                },
+                {
+                  label: '로그아웃',
+                  type: 'action',
+                  onClick: () => {
+                    void handleSignOut();
+                  },
+                  className: 'text-red-500',
+                },
+              ]
             : [
                 {
                   label: '로그인',

--- a/src/app/(seller)/seller/layout.tsx
+++ b/src/app/(seller)/seller/layout.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import { useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
-
-import { authApi } from '@/api/auth/authApi';
+import { useSignOut } from '@/hooks/auth/useSignOut';
 import { useMe } from '@/hooks/users/useMe';
 import { AuthModal } from '@/components/auth/AuthModal';
 import { useAuthModal } from '@/components/auth/useAuthModal';
@@ -19,14 +16,7 @@ export default function SellerLayout({
 }) {
   const { data: user } = useMe();
   const { openAuthModal } = useAuthModal();
-  const router = useRouter();
-  const queryClient = useQueryClient();
-
-  const handleSignOut = async () => {
-    await authApi.signOut();
-    await queryClient.invalidateQueries({ queryKey: ['me'] });
-    router.refresh();
-  };
+  const { mutate: signOut } = useSignOut();
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -44,9 +34,7 @@ export default function SellerLayout({
                 {
                   label: '로그아웃',
                   type: 'action',
-                  onClick: () => {
-                    void handleSignOut();
-                  },
+                  onClick: () => signOut(),
                   className: 'text-red-500',
                 },
               ]


### PR DESCRIPTION
## 📌 작업 내용

- 판매자 페이지 헤더에 로그인 사용자 드롭다운 메뉴 구현
- 로그아웃 클릭 시 세션 초기화
- 비로그인 사용자 로그인 버튼 유지

## 🔧 변경 사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📂 주요 변경 파일

- src/app/(seller)/seller/layout.tsx

## 🧪 테스트 방법

- `/seller` 페이지 접속
- 로그인 상태에서 헤더 유저 이름 클릭 → 소비자 센터, 로그아웃 드롭다운 확인
- 소비자 센터 클릭 → `/` 이동 확인

## 📸 스크린샷 (선택)

<img width="759" height="412" alt="스크린샷 2026-05-19 오전 11 52 22" src="https://github.com/user-attachments/assets/02d61e1b-da9b-402e-89c3-cef1e5a0dafe" />


## 🔗 관련 이슈

- ex) close #133 
