### PR TITLE
feat: 마이페이지 예약 상세 및 픽업 코드 모달 구현

### DIFF
--- a/src/app/api/orders/[orderId]/route.ts
+++ b/src/app/api/orders/[orderId]/route.ts
@@ -2,7 +2,7 @@ import { ERROR_CODE } from '@/lib/errors/errorCodes';
 import { requireActiveUser } from '@/app/api/_lib/auth';
 import { isApiMockEnabled } from '@/app/api/_lib/mock';
 import { fail, routeError, success } from '@/app/api/_lib/response';
-import { mockOrderDetail } from '@/mocks/orders';
+import { mockOrderDetailsMap } from '@/mocks/orders';
 
 import { orderIdSchema } from '../_lib/schemas';
 import { expireUserOrders, getOrder } from '../_lib/service';
@@ -20,7 +20,15 @@ export async function GET(
     ]);
   }
 
-  if (isApiMockEnabled()) return success(mockOrderDetail);
+  if (isApiMockEnabled()) {
+    const mockOrderDetail = mockOrderDetailsMap[parsed.data];
+
+    if (!mockOrderDetail) {
+      return fail(ERROR_CODE.ORDER_NOT_FOUND);
+    }
+
+    return success(mockOrderDetail);
+  }
 
   try {
     const { serviceUser } = await requireActiveUser();

--- a/src/components/consumer/mypage/MypageReservationCard.tsx
+++ b/src/components/consumer/mypage/MypageReservationCard.tsx
@@ -82,7 +82,9 @@ export function MypageReservationCard({
   const displayGroup = statusDisplayMap[reservation.status];
   const status = statusStyles[displayGroup];
   const isPickupCodeAvailable =
-    displayGroup === 'pendingPickup' && Boolean(reservation.pickupCode);
+    (reservation.status === 'reserved' || reservation.status === 'ready') &&
+    Boolean(reservation.pickupCode);
+  const shouldShowPickupCodeButton = displayGroup === 'pendingPickup';
   const reservationTitle = reservation.productName
     ? `${reservation.storeName} ${reservation.productName}`
     : reservation.storeName;
@@ -133,11 +135,6 @@ export function MypageReservationCard({
             <p className="mt-4 text-xl font-bold text-gray-900">
               {reservationTitle}
             </p>
-            {!reservation.productName ? (
-              <p className="mt-2 text-sm text-gray-500">
-                상품 정보는 예약 상세에서 확인할 수 있습니다.
-              </p>
-            ) : null}
             <dl className="mt-4 grid gap-2 text-base md:grid-cols-[72px_minmax(0,1fr)]">
               <dt className="text-gray-500">픽업 날짜</dt>
               <dd className="text-gray-700">
@@ -168,20 +165,19 @@ export function MypageReservationCard({
             >
               예약 상세보기
             </Button>
-            <Button
-              variant={status.actionVariant}
-              color={
-                displayGroup === 'pendingPickup' ||
-                displayGroup === 'paymentPending'
-                  ? 'primary'
-                  : 'gray'
-              }
-              disabled={!isPickupCodeAvailable}
-              className="h-12 min-w-32 px-5 text-sm"
-              onClick={handleOpenPickupCodeModal}
-            >
-              {status.actionLabel}
-            </Button>
+            {shouldShowPickupCodeButton ? (
+              <Button
+                variant={status.actionVariant}
+                color="primary"
+                disabled={!isPickupCodeAvailable}
+                className="h-12 min-w-32 px-5 text-sm"
+                onClick={handleOpenPickupCodeModal}
+              >
+                {reservation.pickupCode
+                  ? '픽업 코드 보기'
+                  : '픽업 코드 발급 전'}
+              </Button>
+            ) : null}
           </div>
         </div>
       </article>
@@ -191,11 +187,13 @@ export function MypageReservationCard({
         reservation={reservation}
         onClose={handleCloseDetailModal}
       />
-      <PickupCodeModal
-        isOpen={isPickupCodeModalOpen}
-        reservation={reservation}
-        onClose={handleClosePickupCodeModal}
-      />
+      {reservation.pickupCode ? (
+        <PickupCodeModal
+          isOpen={isPickupCodeModalOpen}
+          reservation={reservation}
+          onClose={handleClosePickupCodeModal}
+        />
+      ) : null}
     </>
   );
 }

--- a/src/components/consumer/mypage/MypageReservationCard.tsx
+++ b/src/components/consumer/mypage/MypageReservationCard.tsx
@@ -1,9 +1,14 @@
+'use client';
+
 import Image from 'next/image';
+import { useState } from 'react';
 
 import type { OrderStatus } from '@/types/order';
 import { Button } from '@/components/common';
 
+import { MypageReservationDetailModal } from './MypageReservationDetailModal';
 import type { MypageReservation } from './mypageReservationMapper';
+import { PickupCodeModal } from './PickupCodeModal';
 
 interface MypageReservationCardProps {
   reservation: MypageReservation;
@@ -72,87 +77,125 @@ const statusStyles: Record<
 export function MypageReservationCard({
   reservation,
 }: MypageReservationCardProps) {
+  const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
+  const [isPickupCodeModalOpen, setIsPickupCodeModalOpen] = useState(false);
   const displayGroup = statusDisplayMap[reservation.status];
   const status = statusStyles[displayGroup];
+  const isPickupCodeAvailable =
+    displayGroup === 'pendingPickup' && Boolean(reservation.pickupCode);
   const reservationTitle = reservation.productName
     ? `${reservation.storeName} ${reservation.productName}`
     : reservation.storeName;
 
+  const handleOpenDetailModal = () => {
+    setIsDetailModalOpen(true);
+  };
+
+  const handleCloseDetailModal = () => {
+    setIsDetailModalOpen(false);
+  };
+
+  const handleOpenPickupCodeModal = () => {
+    if (!isPickupCodeAvailable) {
+      return;
+    }
+
+    setIsPickupCodeModalOpen(true);
+  };
+
+  const handleClosePickupCodeModal = () => {
+    setIsPickupCodeModalOpen(false);
+  };
+
   return (
-    <article className="rounded-lg border border-gray-200 bg-white p-5">
-      <div className="grid gap-12 md:grid-cols-[150px_minmax(0,1fr)_120px_240px] md:items-center">
-        <div className="relative aspect-square overflow-hidden rounded-md bg-gray-100">
-          <Image
-            src={reservation.imageUrl}
-            alt={reservationTitle}
-            fill
-            sizes="150px"
-            className="object-cover"
-          />
-        </div>
+    <>
+      <article className="rounded-lg border border-gray-200 bg-white p-5">
+        <div className="grid gap-12 md:grid-cols-[150px_minmax(0,1fr)_120px_240px] md:items-center">
+          <div className="relative aspect-square overflow-hidden rounded-md bg-gray-100">
+            <Image
+              src={reservation.imageUrl}
+              alt={reservationTitle}
+              fill
+              sizes="150px"
+              className="object-cover"
+            />
+          </div>
 
-        <div className="min-w-0">
-          <span
-            className={[
-              'inline-flex rounded-sm px-3 py-1 text-xs font-bold',
-              status.className,
-            ].join(' ')}
-          >
-            {status.label}
-          </span>
-          <p className="mt-4 text-xl font-bold text-gray-900">
-            {reservationTitle}
-          </p>
-          {!reservation.productName ? (
-            <p className="mt-2 text-sm text-gray-500">
-              상품 정보는 예약 상세에서 확인할 수 있습니다.
+          <div className="min-w-0">
+            <span
+              className={[
+                'inline-flex rounded-sm px-3 py-1 text-xs font-bold',
+                status.className,
+              ].join(' ')}
+            >
+              {status.label}
+            </span>
+            <p className="mt-4 text-xl font-bold text-gray-900">
+              {reservationTitle}
             </p>
-          ) : null}
-          <dl className="mt-4 grid gap-2 text-base md:grid-cols-[72px_minmax(0,1fr)]">
-            <dt className="text-gray-500">픽업 날짜</dt>
-            <dd className="text-gray-700">
-              {reservation.pickupDate} &nbsp; {reservation.pickupTime}
-            </dd>
-            <dt className="text-gray-500">주문번호</dt>
-            <dd className="text-gray-700">{reservation.orderNumber}</dd>
-          </dl>
-        </div>
+            {!reservation.productName ? (
+              <p className="mt-2 text-sm text-gray-500">
+                상품 정보는 예약 상세에서 확인할 수 있습니다.
+              </p>
+            ) : null}
+            <dl className="mt-4 grid gap-2 text-base md:grid-cols-[72px_minmax(0,1fr)]">
+              <dt className="text-gray-500">픽업 날짜</dt>
+              <dd className="text-gray-700">
+                {reservation.pickupDate} &nbsp; {reservation.pickupTime}
+              </dd>
+              <dt className="text-gray-500">주문번호</dt>
+              <dd className="text-gray-700">{reservation.orderNumber}</dd>
+            </dl>
+          </div>
 
-        <div>
-          <p className="text-2xl font-bold text-gray-900">
-            {reservation.price.toLocaleString()}원
-          </p>
-          {reservation.quantity ? (
-            <p className="mt-2 text-base text-gray-500">
-              수량&nbsp; {reservation.quantity}개
+          <div>
+            <p className="text-2xl font-bold text-gray-900">
+              {reservation.price.toLocaleString()}원
             </p>
-          ) : null}
-        </div>
+            {reservation.quantity ? (
+              <p className="mt-2 text-base text-gray-500">
+                수량&nbsp; {reservation.quantity}개
+              </p>
+            ) : null}
+          </div>
 
-        <div className="flex gap-2 md:justify-end">
-          <Button
-            variant="outline"
-            color="gray"
-            disabled
-            className="h-12 min-w-32 px-5 text-sm"
-          >
-            예약 상세보기
-          </Button>
-          <Button
-            variant={status.actionVariant}
-            color={
-              displayGroup === 'pendingPickup' ||
-              displayGroup === 'paymentPending'
-                ? 'primary'
-                : 'gray'
-            }
-            disabled
-            className="h-12 min-w-32 px-5 text-sm"
-          >
-            {status.actionLabel}
-          </Button>
+          <div className="flex gap-2 md:justify-end">
+            <Button
+              variant="outline"
+              color="gray"
+              className="h-12 min-w-32 px-5 text-sm"
+              onClick={handleOpenDetailModal}
+            >
+              예약 상세보기
+            </Button>
+            <Button
+              variant={status.actionVariant}
+              color={
+                displayGroup === 'pendingPickup' ||
+                displayGroup === 'paymentPending'
+                  ? 'primary'
+                  : 'gray'
+              }
+              disabled={!isPickupCodeAvailable}
+              className="h-12 min-w-32 px-5 text-sm"
+              onClick={handleOpenPickupCodeModal}
+            >
+              {status.actionLabel}
+            </Button>
+          </div>
         </div>
-      </div>
-    </article>
+      </article>
+
+      <MypageReservationDetailModal
+        isOpen={isDetailModalOpen}
+        reservation={reservation}
+        onClose={handleCloseDetailModal}
+      />
+      <PickupCodeModal
+        isOpen={isPickupCodeModalOpen}
+        reservation={reservation}
+        onClose={handleClosePickupCodeModal}
+      />
+    </>
   );
 }

--- a/src/components/consumer/mypage/MypageReservationCard.tsx
+++ b/src/components/consumer/mypage/MypageReservationCard.tsx
@@ -82,8 +82,7 @@ export function MypageReservationCard({
   const displayGroup = statusDisplayMap[reservation.status];
   const status = statusStyles[displayGroup];
   const isPickupCodeAvailable =
-    (reservation.status === 'reserved' || reservation.status === 'ready') &&
-    Boolean(reservation.pickupCode);
+    displayGroup === 'pendingPickup' && Boolean(reservation.pickupCode);
   const shouldShowPickupCodeButton = displayGroup === 'pendingPickup';
   const reservationTitle = reservation.productName
     ? `${reservation.storeName} ${reservation.productName}`

--- a/src/components/consumer/mypage/MypageReservationDetailModal.tsx
+++ b/src/components/consumer/mypage/MypageReservationDetailModal.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 
+import { useOrder } from '@/hooks/orders/useOrder';
 import { Modal } from '@/components/common';
 
 import type { MypageReservation } from './mypageReservationMapper';
@@ -15,7 +16,26 @@ export function MypageReservationDetailModal({
   reservation,
   onClose,
 }: MypageReservationDetailModalProps) {
-  const reservationTitle = reservation.productName ?? reservation.storeName;
+  const {
+    data: orderDetail,
+    isError,
+    isFetching,
+    isLoading,
+    refetch,
+  } = useOrder(isOpen ? reservation.id : '');
+  const orderItems = orderDetail?.items ?? [];
+  const totalQuantity =
+    orderItems.length > 0
+      ? orderItems.reduce((sum, item) => sum + item.quantity, 0)
+      : reservation.quantity;
+  const reservationTitle =
+    orderItems[0]?.productName ??
+    reservation.productName ??
+    reservation.storeName;
+
+  const handleRetryOrderDetail = () => {
+    void refetch();
+  };
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="예약 상세보기" size="md">
@@ -29,6 +49,63 @@ export function MypageReservationDetailModal({
           </h2>
         </div>
 
+        {isLoading ? (
+          <div
+            role="status"
+            aria-live="polite"
+            className="rounded-md border border-dashed border-gray-200 bg-gray-50 px-4 py-5 text-center text-sm font-medium text-gray-500"
+          >
+            예약 상세 정보를 불러오는 중입니다.
+          </div>
+        ) : null}
+
+        {isError && !orderDetail ? (
+          <div
+            role="alert"
+            className="rounded-md border border-dashed border-red-200 bg-red-50 px-4 py-5 text-center"
+          >
+            <p className="text-sm font-semibold text-red-500">
+              예약 상세 정보를 불러오지 못했습니다.
+            </p>
+            <button
+              type="button"
+              disabled={isFetching}
+              onClick={handleRetryOrderDetail}
+              className="mt-3 rounded-sm border border-red-200 px-3 py-2 text-sm font-semibold text-red-500 transition hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isFetching ? '다시 불러오는 중' : '다시 시도'}
+            </button>
+          </div>
+        ) : null}
+
+        {orderItems.length > 0 ? (
+          <section>
+            <h3 className="mb-3 text-sm font-bold text-gray-900">주문 상품</h3>
+            <ul className="space-y-3">
+              {orderItems.map((item) => (
+                <li
+                  key={item.id}
+                  className="rounded-md border border-gray-100 bg-gray-50 px-4 py-3"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <p className="text-sm font-semibold text-gray-900">
+                        {item.productName}
+                      </p>
+                      <p className="mt-1 text-xs text-gray-500">
+                        수량 {item.quantity}개
+                      </p>
+                    </div>
+                    <p className="text-sm font-bold text-gray-900">
+                      {item.subtotal.toLocaleString()}원
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+
         <dl className="grid gap-4 text-sm">
           <ReservationDetailRow label="주문번호">
             {reservation.orderNumber}
@@ -40,7 +117,7 @@ export function MypageReservationDetailModal({
             {reservation.pickupTime}
           </ReservationDetailRow>
           <ReservationDetailRow label="수량">
-            {reservation.quantity ? `${reservation.quantity}개` : '확인 중'}
+            {totalQuantity ? `${totalQuantity}개` : '확인 중'}
           </ReservationDetailRow>
           <ReservationDetailRow label="결제 금액">
             {reservation.price.toLocaleString()}원

--- a/src/components/consumer/mypage/MypageReservationDetailModal.tsx
+++ b/src/components/consumer/mypage/MypageReservationDetailModal.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from 'react';
+
+import { Modal } from '@/components/common';
+
+import type { MypageReservation } from './mypageReservationMapper';
+
+interface MypageReservationDetailModalProps {
+  isOpen: boolean;
+  reservation: MypageReservation;
+  onClose: () => void;
+}
+
+export function MypageReservationDetailModal({
+  isOpen,
+  reservation,
+  onClose,
+}: MypageReservationDetailModalProps) {
+  const reservationTitle = reservation.productName ?? reservation.storeName;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="예약 상세보기" size="md">
+      <div className="space-y-6">
+        <div>
+          <p className="text-primary-500 text-sm font-semibold">
+            {reservation.storeName}
+          </p>
+          <h2 className="mt-2 text-xl font-bold text-gray-900">
+            {reservationTitle}
+          </h2>
+        </div>
+
+        <dl className="grid gap-4 text-sm">
+          <ReservationDetailRow label="주문번호">
+            {reservation.orderNumber}
+          </ReservationDetailRow>
+          <ReservationDetailRow label="픽업 날짜">
+            {reservation.pickupDate}
+          </ReservationDetailRow>
+          <ReservationDetailRow label="픽업 시간">
+            {reservation.pickupTime}
+          </ReservationDetailRow>
+          <ReservationDetailRow label="수량">
+            {reservation.quantity ? `${reservation.quantity}개` : '확인 중'}
+          </ReservationDetailRow>
+          <ReservationDetailRow label="결제 금액">
+            {reservation.price.toLocaleString()}원
+          </ReservationDetailRow>
+        </dl>
+      </div>
+    </Modal>
+  );
+}
+
+interface ReservationDetailRowProps {
+  label: string;
+  children: ReactNode;
+}
+
+function ReservationDetailRow({ label, children }: ReservationDetailRowProps) {
+  return (
+    <div className="grid grid-cols-[88px_minmax(0,1fr)] gap-4 border-b border-gray-100 pb-4 last:border-b-0 last:pb-0">
+      <dt className="font-semibold text-gray-500">{label}</dt>
+      <dd className="font-medium text-gray-900">{children}</dd>
+    </div>
+  );
+}

--- a/src/components/consumer/mypage/PickupCodeModal.tsx
+++ b/src/components/consumer/mypage/PickupCodeModal.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from 'react';
+
+import { Modal } from '@/components/common';
+
+import type { MypageReservation } from './mypageReservationMapper';
+
+interface PickupCodeModalProps {
+  isOpen: boolean;
+  reservation: MypageReservation;
+  onClose: () => void;
+}
+
+export function PickupCodeModal({
+  isOpen,
+  reservation,
+  onClose,
+}: PickupCodeModalProps) {
+  const reservationTitle = reservation.productName ?? reservation.storeName;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="픽업 코드 보기" size="sm">
+      <div className="space-y-6">
+        <div className="bg-primary-50 rounded-lg px-5 py-6 text-center">
+          <p className="text-primary-500 text-sm font-semibold">픽업 코드</p>
+          <p className="text-primary-600 mt-3 text-3xl font-black tracking-wide">
+            {reservation.pickupCode}
+          </p>
+          <p className="mt-4 text-sm leading-6 text-gray-600">
+            매장 직원에게 이 화면을 보여주세요.
+          </p>
+        </div>
+
+        <dl className="grid gap-3 text-sm">
+          <PickupCodeInfoRow label="상품">{reservationTitle}</PickupCodeInfoRow>
+          <PickupCodeInfoRow label="매장">
+            {reservation.storeName}
+          </PickupCodeInfoRow>
+          <PickupCodeInfoRow label="픽업">
+            {reservation.pickupDate} {reservation.pickupTime}
+          </PickupCodeInfoRow>
+        </dl>
+      </div>
+    </Modal>
+  );
+}
+
+interface PickupCodeInfoRowProps {
+  label: string;
+  children: ReactNode;
+}
+
+function PickupCodeInfoRow({ label, children }: PickupCodeInfoRowProps) {
+  return (
+    <div className="grid grid-cols-[56px_minmax(0,1fr)] gap-3">
+      <dt className="font-semibold text-gray-500">{label}</dt>
+      <dd className="font-medium text-gray-900">{children}</dd>
+    </div>
+  );
+}

--- a/src/components/consumer/mypage/mypageReservationMapper.ts
+++ b/src/components/consumer/mypage/mypageReservationMapper.ts
@@ -10,7 +10,7 @@ export interface MypageReservation {
   imageUrl: string;
   pickupDate: string;
   pickupTime: string;
-  pickupCode: string;
+  pickupCode: string | null;
   quantity: number | null;
   price: number;
   status: OrderStatus;
@@ -54,8 +54,7 @@ export function mapOrderToMypageReservation(
     imageUrl: FALLBACK_RESERVATION_IMAGE_URL,
     pickupDate: formatPickupDate(order.pickupAt),
     pickupTime: formatPickupTime(order.pickupAt),
-    pickupCode:
-      order.pickupNumber ?? order.storeOrderNumber ?? order.orderNumber,
+    pickupCode: order.pickupNumber ?? null,
     quantity: null,
     price: order.paymentAmount,
     status: order.status,

--- a/src/components/consumer/mypage/mypageReservationMapper.ts
+++ b/src/components/consumer/mypage/mypageReservationMapper.ts
@@ -10,6 +10,7 @@ export interface MypageReservation {
   imageUrl: string;
   pickupDate: string;
   pickupTime: string;
+  pickupCode: string;
   quantity: number | null;
   price: number;
   status: OrderStatus;
@@ -53,6 +54,8 @@ export function mapOrderToMypageReservation(
     imageUrl: FALLBACK_RESERVATION_IMAGE_URL,
     pickupDate: formatPickupDate(order.pickupAt),
     pickupTime: formatPickupTime(order.pickupAt),
+    pickupCode:
+      order.pickupNumber ?? order.storeOrderNumber ?? order.orderNumber,
     quantity: null,
     price: order.paymentAmount,
     status: order.status,

--- a/src/mocks/orders.ts
+++ b/src/mocks/orders.ts
@@ -7,8 +7,15 @@ import type {
 
 import { mockPaymentResponse } from './payments';
 
+const MOCK_ORDER_ID_1 = '00000000-0000-4000-8000-000000000701';
+const MOCK_ORDER_ID_2 = '00000000-0000-4000-8000-000000000702';
+const MOCK_ORDER_ID_3 = '00000000-0000-4000-8000-000000000703';
+const MOCK_ORDER_ITEM_ID_1 = '00000000-0000-4000-8000-000000000801';
+const MOCK_ORDER_ITEM_ID_2 = '00000000-0000-4000-8000-000000000802';
+const MOCK_ORDER_ITEM_ID_3 = '00000000-0000-4000-8000-000000000803';
+
 export const mockCreatedOrder: CreateOrderResponse = {
-  id: 'order_1',
+  id: MOCK_ORDER_ID_1,
   orderNumber: 'PM20260429A1B2C3D4E5',
   orderName: '마감 할인 크루아상 세트 1개',
   paymentAmount: 7200,
@@ -17,8 +24,8 @@ export const mockCreatedOrder: CreateOrderResponse = {
 
 export const mockOrderItems = [
   {
-    id: 'order_item_1',
-    orderId: 'order_1',
+    id: MOCK_ORDER_ITEM_ID_1,
+    orderId: MOCK_ORDER_ID_1,
     productId: 'product_1',
     productName: '마감 할인 크루아상 세트',
     originalPrice: 12000,
@@ -27,11 +34,33 @@ export const mockOrderItems = [
     subtotal: 7200,
     createdAt: '2026-04-29T10:00:00.000Z',
   },
+  {
+    id: MOCK_ORDER_ITEM_ID_2,
+    orderId: MOCK_ORDER_ID_2,
+    productId: 'product_2',
+    productName: '오늘의 샐러드 박스',
+    originalPrice: 9800,
+    discountPrice: 5900,
+    quantity: 1,
+    subtotal: 5900,
+    createdAt: '2026-04-29T10:10:00.000Z',
+  },
+  {
+    id: MOCK_ORDER_ITEM_ID_3,
+    orderId: MOCK_ORDER_ID_3,
+    productId: 'product_3',
+    productName: '제육볶음 도시락',
+    originalPrice: 11000,
+    discountPrice: 7700,
+    quantity: 1,
+    subtotal: 7700,
+    createdAt: '2026-04-28T10:30:00.000Z',
+  },
 ];
 
 export const mockOrders: OrderListItemResponse[] = [
   {
-    id: 'order_1',
+    id: MOCK_ORDER_ID_1,
     orderNumber: 'PM20260429A1B2C3D4E5',
     storeId: 'store_1',
     storeName: '픽마 베이커리',
@@ -48,7 +77,7 @@ export const mockOrders: OrderListItemResponse[] = [
     updatedAt: '2026-04-29T10:01:00.000Z',
   },
   {
-    id: 'order_2',
+    id: MOCK_ORDER_ID_2,
     orderNumber: 'PM20260429F6A7B8C9D0',
     storeId: 'store_2',
     storeName: '그린 샐러드',
@@ -63,7 +92,7 @@ export const mockOrders: OrderListItemResponse[] = [
     updatedAt: '2026-04-29T10:10:00.000Z',
   },
   {
-    id: 'order_3',
+    id: MOCK_ORDER_ID_3,
     orderNumber: 'PM20260429E1F2A3B4C5',
     storeId: 'store_3',
     storeName: '든든도시락 역삼점',
@@ -82,9 +111,21 @@ export const mockOrders: OrderListItemResponse[] = [
 
 export const mockOrderDetail: OrderDetailResponse = {
   ...mockOrders[0],
-  items: mockOrderItems,
+  items: mockOrderItems.filter((item) => item.orderId === mockOrders[0].id),
   payment: mockPaymentResponse,
 };
+
+export const mockOrderDetailsMap: Record<string, OrderDetailResponse> =
+  Object.fromEntries(
+    mockOrders.map((order) => [
+      order.id,
+      {
+        ...order,
+        items: mockOrderItems.filter((item) => item.orderId === order.id),
+        payment: mockPaymentResponse,
+      },
+    ])
+  );
 
 export const mockOrderList: OrderListResponse = {
   items: mockOrders,

--- a/src/mocks/orders.ts
+++ b/src/mocks/orders.ts
@@ -5,8 +5,6 @@ import type {
   OrderListResponse,
 } from '@/contracts/order';
 
-import { mockPaymentResponse } from './payments';
-
 const MOCK_ORDER_ID_1 = '00000000-0000-4000-8000-000000000701';
 const MOCK_ORDER_ID_2 = '00000000-0000-4000-8000-000000000702';
 const MOCK_ORDER_ID_3 = '00000000-0000-4000-8000-000000000703';
@@ -112,7 +110,6 @@ export const mockOrders: OrderListItemResponse[] = [
 export const mockOrderDetail: OrderDetailResponse = {
   ...mockOrders[0],
   items: mockOrderItems.filter((item) => item.orderId === mockOrders[0].id),
-  payment: mockPaymentResponse,
 };
 
 export const mockOrderDetailsMap: Record<string, OrderDetailResponse> =
@@ -122,7 +119,6 @@ export const mockOrderDetailsMap: Record<string, OrderDetailResponse> =
       {
         ...order,
         items: mockOrderItems.filter((item) => item.orderId === order.id),
-        payment: mockPaymentResponse,
       },
     ])
   );


### PR DESCRIPTION
## 📌 작업 내용

- 마이페이지 예약 목록에서 예약 상세보기 / 픽업 코드 보기 모달을 추가했습니다.
- 예약 상세 모달에서 주문 상세 API를 조회해 주문 상품 정보를 표시하도록 연결했습니다.
- 픽업 코드 모달은 실제 pickupNumber가 있는 예약에서만 열리도록 처리했습니다.
- mock 주문 상세 응답을 주문 ID별로 분리해 mock 환경에서도 선택한 예약과 상세 정보가 일치하도록 정리했습니다.

## 🔧 변경 사항

- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📂 주요 변경 파일

- `MypageReservationList.tsx`
- `MypageReservationCard.tsx`
- `MypageReservationDetailModal.tsx`
- `PickupCodeModal.tsx`
- `mypageReservationMapper.ts`
- `src/app/api/orders/[orderId]/route.ts`
- `src/mocks/orders.ts`
- `src/mocks/mypage.ts`

## 🧪 테스트 방법

- `/mypage` 접속
- 예약 카드에서 `예약 상세보기` 클릭
- 예약 상세 모달이 열리고 주문 상세 정보가 표시되는지 확인
- pickupNumber가 있는 예약에서 `픽업 코드 보기` 클릭
- 픽업 코드 모달이 열리는지 확인
- pickupNumber가 없는 예약에서는 픽업 코드 버튼이 비활성/미노출 처리되는지 확인
- mock 환경에서 각 예약의 상세 정보가 선택한 주문 ID에 맞게 표시되는지 확인

## 📸 스크린샷 (선택)

- 마이페이지 예약 상세 모달
- 픽업 코드 모달

## 🔗 관련 이슈

- close #112 

## 📝 참고 사항

- 결제하기 / 다시 예약 / 내역 보기 등 다른 상태별 액션은 후속 이슈에서 실제 플로우와 연결할 예정입니다.
- 주문 상세 API 응답에 상품 이미지나 추가 상품 정보가 확장되면 모달 표시 정보도 함께 보강할 수 있습니다.
