### PR TITLE
feat: 상품 상세 예약 주문 결제 흐름 연결

### DIFF
--- a/src/app/(consumer)/order/[productId]/page.tsx
+++ b/src/app/(consumer)/order/[productId]/page.tsx
@@ -1,17 +1,4 @@
-import { notFound } from 'next/navigation';
-
-import {
-  createPickupTimeOptions,
-  type PickupTimeOption,
-} from '@/lib/formatPickupTime';
-import { Footer } from '@/components/common';
-import { ConsumerHeader } from '@/components/consumer/ConsumerHeader';
-import {
-  OrderCheckoutPanel,
-  OrderProductSummary,
-  OrderProgressSteps,
-} from '@/components/consumer/order';
-import { mockProductDetailsMap } from '@/mocks/products';
+import { OrderPageContainer } from '@/components/consumer/order/OrderPageContainer';
 
 interface OrderPageProps {
   params: Promise<{ productId: string }>;
@@ -22,107 +9,17 @@ interface OrderPageProps {
   }>;
 }
 
-const DEFAULT_ORDER_QUANTITY = 1;
-const SERVICE_FEE = 0;
-
-function getSearchParamValue(value: string | string[] | undefined) {
-  return Array.isArray(value) ? value[0] : value;
-}
-
-function parseOrderQuantity(
-  value: string | string[] | undefined,
-  availableStock: number
-) {
-  const rawQuantity = Number(getSearchParamValue(value));
-
-  if (!Number.isInteger(rawQuantity) || rawQuantity <= 0) {
-    return DEFAULT_ORDER_QUANTITY;
-  }
-
-  return Math.min(rawQuantity, Math.max(availableStock, 1));
-}
-
-function createInitialPickupTime(
-  pickupStart: string | string[] | undefined,
-  pickupEnd: string | string[] | undefined,
-  productPickupStartTime: string,
-  productPickupEndTime: string
-): PickupTimeOption | undefined {
-  const startAt = getSearchParamValue(pickupStart);
-  const endAt = getSearchParamValue(pickupEnd);
-
-  if (!startAt || !endAt) {
-    return undefined;
-  }
-
-  return createPickupTimeOptions(
-    productPickupStartTime,
-    productPickupEndTime
-  ).find((option) => option.startAt === startAt && option.endAt === endAt);
-}
-
 export default async function OrderPage({
   params,
   searchParams,
 }: OrderPageProps) {
   const { productId } = await params;
   const resolvedSearchParams = await searchParams;
-  const product = mockProductDetailsMap[productId];
-
-  if (!product) {
-    notFound();
-  }
-
-  const orderQuantity = parseOrderQuantity(
-    resolvedSearchParams.quantity,
-    product.availableStock
-  );
-  const initialPickupTime = createInitialPickupTime(
-    resolvedSearchParams.pickupStart,
-    resolvedSearchParams.pickupEnd,
-    product.pickupStartTime,
-    product.pickupEndTime
-  );
-  const productTotalPrice = product.discountPrice * orderQuantity;
-  const originalTotalPrice = product.originalPrice * orderQuantity;
-  const discountAmount = originalTotalPrice - productTotalPrice;
-  const finalPaymentPrice = productTotalPrice + SERVICE_FEE;
 
   return (
-    <div className="bg-white">
-      <ConsumerHeader />
-
-      <main className="min-h-screen bg-white">
-        <section className="mx-auto max-w-450 px-6 py-10">
-          <h1 className="text-3xl font-bold text-gray-900">주문/결제</h1>
-
-          <div className="mt-10 grid gap-10 lg:grid-cols-[minmax(0,1fr)_440px]">
-            <div className="space-y-8">
-              <OrderProgressSteps currentStep="order" />
-
-              <OrderProductSummary
-                product={product}
-                quantity={orderQuantity}
-                serviceFee={SERVICE_FEE}
-                productTotalPrice={productTotalPrice}
-                discountAmount={discountAmount}
-                finalPaymentPrice={finalPaymentPrice}
-              />
-            </div>
-
-            <aside className="lg:sticky lg:top-24 lg:self-start">
-              <OrderCheckoutPanel
-                product={product}
-                quantity={orderQuantity}
-                finalPaymentPrice={finalPaymentPrice}
-                initialPickupTime={initialPickupTime}
-              />
-            </aside>
-          </div>
-        </section>
-      </main>
-
-      <Footer />
-    </div>
+    <OrderPageContainer
+      productId={productId}
+      searchParams={resolvedSearchParams}
+    />
   );
 }

--- a/src/components/consumer/ProductCard.tsx
+++ b/src/components/consumer/ProductCard.tsx
@@ -14,6 +14,8 @@ type ProductCardProps = {
   product: Product;
 };
 
+const FALLBACK_PRODUCT_IMAGE = '/images/products/noimage.png';
+
 // 마감 시간
 function formatRemainingTime(endAt: Date, now: number) {
   const remainingSeconds = Math.max(
@@ -50,7 +52,7 @@ export function ProductCard({ product }: ProductCardProps) {
 
       <div className="relative aspect-video">
         <Image
-          src={product.image ?? '/images/products/bread.jpg'}
+          src={product.image || FALLBACK_PRODUCT_IMAGE}
           alt={product.name}
           fill
           sizes="(min-width:1280px) 25vw, (min-width:768px) 33vw, 100vw"

--- a/src/components/consumer/ProductReservationPanel.tsx
+++ b/src/components/consumer/ProductReservationPanel.tsx
@@ -10,6 +10,11 @@ import {
 import { useRouter } from 'next/navigation';
 import { useMemo, useState } from 'react';
 
+import {
+  createPickupTimeOptions,
+  formatPickupDateLabel,
+  isPastPickupTimeSlot,
+} from '@/lib/formatPickupTime';
 import { Button } from '@/components/common';
 
 interface ProductReservationPanelProps {
@@ -18,105 +23,6 @@ interface ProductReservationPanelProps {
   availableStock: number;
   pickupStartTime: string;
   pickupEndTime: string;
-}
-
-function formatPickupDate(value: string) {
-  if (!value.includes('T')) {
-    return '오늘';
-  }
-
-  const date = new Date(value);
-
-  if (Number.isNaN(date.getTime())) {
-    return '오늘';
-  }
-
-  return new Intl.DateTimeFormat('ko-KR', {
-    month: 'numeric',
-    day: 'numeric',
-    weekday: 'short',
-  }).format(date);
-}
-
-function createPickupTimeSlots(startTime: string, endTime: string) {
-  const start = parseTimeToMinutes(startTime);
-  const end = parseTimeToMinutes(endTime);
-  const slots: { label: string; value: string }[] = [];
-
-  if (start === null || end === null || start >= end) {
-    return slots;
-  }
-
-  for (let current = start; current + 30 <= end; current += 30) {
-    const next = current + 30;
-    slots.push({
-      value: `${formatMinutesToTime(current)}-${formatMinutesToTime(next)}`,
-      label: `${formatMinutesToTime(current)}~${formatMinutesToTime(next)}`,
-    });
-  }
-
-  return slots;
-}
-
-function parseTimeToMinutes(value: string) {
-  const time = value.includes('T') ? value.split('T')[1] : value;
-  const [hour, minute] = time.split(':').map(Number);
-
-  if (
-    Number.isNaN(hour) ||
-    Number.isNaN(minute) ||
-    hour < 0 ||
-    hour > 23 ||
-    minute < 0 ||
-    minute > 59
-  ) {
-    return null;
-  }
-
-  return hour * 60 + minute;
-}
-
-function formatMinutesToTime(totalMinutes: number) {
-  const hour = Math.floor(totalMinutes / 60);
-  const minute = totalMinutes % 60;
-
-  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
-}
-
-function isPastTimeSlot(slotValue: string, pickupDateTime: string, now: Date) {
-  const [startTime] = slotValue.split('-');
-  const slotStartMinutes = parseTimeToMinutes(startTime);
-
-  if (slotStartMinutes === null) {
-    return true;
-  }
-
-  if (pickupDateTime.includes('T')) {
-    const pickupDate = new Date(pickupDateTime);
-
-    if (Number.isNaN(pickupDate.getTime())) {
-      return true;
-    }
-
-    const pickupDateOnly = new Date(
-      pickupDate.getFullYear(),
-      pickupDate.getMonth(),
-      pickupDate.getDate()
-    );
-    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-
-    if (pickupDateOnly.getTime() > today.getTime()) {
-      return false;
-    }
-
-    if (pickupDateOnly.getTime() < today.getTime()) {
-      return true;
-    }
-  }
-
-  const nowMinutes = now.getHours() * 60 + now.getMinutes();
-
-  return slotStartMinutes <= nowMinutes;
 }
 
 export function ProductReservationPanel({
@@ -129,18 +35,19 @@ export function ProductReservationPanel({
   const router = useRouter();
   const [now] = useState(() => new Date());
   const timeSlots = useMemo(
-    () => createPickupTimeSlots(pickupStartTime, pickupEndTime),
+    () => createPickupTimeOptions(pickupStartTime, pickupEndTime),
     [pickupStartTime, pickupEndTime]
   );
   const [selectedTimeSlot, setSelectedTimeSlot] = useState('');
 
   const selectedSlot = timeSlots.find(
-    (slot) => slot.value === selectedTimeSlot
+    (slot) => slot.startAt === selectedTimeSlot
   );
   const activeTimeSlot =
-    selectedSlot && !isPastTimeSlot(selectedSlot.value, pickupStartTime, now)
-      ? selectedSlot.value
-      : '';
+    selectedSlot &&
+    !isPastPickupTimeSlot(selectedSlot.startAt, pickupStartTime, now)
+      ? selectedSlot
+      : null;
 
   const [quantity, setQuantity] = useState(() => (availableStock > 0 ? 1 : 0));
 
@@ -152,20 +59,19 @@ export function ProductReservationPanel({
   };
   const handleAddButtonClick = () => {
     if (
-      activeTimeSlot === '' ||
+      activeTimeSlot === null ||
       availableStock <= 0 ||
       quantity <= 0 ||
-      isPastTimeSlot(activeTimeSlot, pickupStartTime, new Date())
+      isPastPickupTimeSlot(activeTimeSlot.startAt, pickupStartTime, new Date())
     ) {
       setSelectedTimeSlot('');
       return;
     }
 
-    const [pickupStart, pickupEnd] = activeTimeSlot.split('-');
     const searchParams = new URLSearchParams({
       quantity: String(quantity),
-      pickupStart,
-      pickupEnd,
+      pickupStart: activeTimeSlot.startAt,
+      pickupEnd: activeTimeSlot.endAt,
     });
 
     router.push(`/order/${productId}?${searchParams.toString()}`);
@@ -173,7 +79,7 @@ export function ProductReservationPanel({
   const isDecreaseDisabled = quantity <= 1;
   const isIncreaseDisabled = quantity >= availableStock;
   const isAddButtonDisabled =
-    activeTimeSlot === '' || availableStock <= 0 || quantity <= 0;
+    activeTimeSlot === null || availableStock <= 0 || quantity <= 0;
 
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6">
@@ -191,7 +97,7 @@ export function ProductReservationPanel({
         </button>
 
         <span className="text-base font-semibold text-gray-900">
-          {formatPickupDate(pickupStartTime)}
+          {formatPickupDateLabel(pickupStartTime, now) ?? '-'}
         </span>
 
         <button
@@ -206,12 +112,16 @@ export function ProductReservationPanel({
 
       <div className="mt-3 mb-6 grid max-h-42 grid-cols-3 gap-2 overflow-y-auto pr-1">
         {timeSlots.map((slot) => {
-          const isSelected = activeTimeSlot === slot.value;
-          const isDisabled = isPastTimeSlot(slot.value, pickupStartTime, now);
+          const isSelected = activeTimeSlot?.startAt === slot.startAt;
+          const isDisabled = isPastPickupTimeSlot(
+            slot.startAt,
+            pickupStartTime,
+            now
+          );
 
           return (
             <Button
-              key={slot.value}
+              key={slot.startAt}
               type="button"
               variant="outline"
               color={isSelected ? 'primary' : 'gray'}
@@ -222,7 +132,7 @@ export function ProductReservationPanel({
                 isSelected && !isDisabled ? 'bg-primary-50' : 'bg-white',
                 isDisabled ? 'text-gray-300' : '',
               ].join(' ')}
-              onClick={() => setSelectedTimeSlot(slot.value)}
+              onClick={() => setSelectedTimeSlot(slot.startAt)}
             >
               {slot.label}
             </Button>

--- a/src/components/consumer/mypage/MypageReservationCard.tsx
+++ b/src/components/consumer/mypage/MypageReservationCard.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { useState } from 'react';
 
 import type { OrderStatus } from '@/types/order';
+import { usePayment } from '@/hooks/payments/usePayment';
 import { Button } from '@/components/common';
 
 import { MypageReservationDetailModal } from './MypageReservationDetailModal';
@@ -77,6 +78,7 @@ const statusStyles: Record<
 export function MypageReservationCard({
   reservation,
 }: MypageReservationCardProps) {
+  const { openPayment, isPending: isPaymentPending } = usePayment();
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
   const [isPickupCodeModalOpen, setIsPickupCodeModalOpen] = useState(false);
   const displayGroup = statusDisplayMap[reservation.status];
@@ -84,6 +86,7 @@ export function MypageReservationCard({
   const isPickupCodeAvailable =
     displayGroup === 'pendingPickup' && Boolean(reservation.pickupCode);
   const shouldShowPickupCodeButton = displayGroup === 'pendingPickup';
+  const shouldShowPaymentButton = displayGroup === 'paymentPending';
   const reservationTitle = reservation.productName
     ? `${reservation.storeName} ${reservation.productName}`
     : reservation.storeName;
@@ -106,6 +109,13 @@ export function MypageReservationCard({
 
   const handleClosePickupCodeModal = () => {
     setIsPickupCodeModalOpen(false);
+  };
+
+  const handleOpenPayment = async () => {
+    await openPayment({
+      orderNumber: reservation.orderNumber,
+      orderName: reservationTitle,
+    });
   };
 
   return (
@@ -175,6 +185,16 @@ export function MypageReservationCard({
                 {reservation.pickupCode
                   ? '픽업 코드 보기'
                   : '픽업 코드 발급 전'}
+              </Button>
+            ) : null}
+            {shouldShowPaymentButton ? (
+              <Button
+                color="primary"
+                disabled={isPaymentPending}
+                className="h-12 min-w-32 px-5 text-sm"
+                onClick={() => void handleOpenPayment()}
+              >
+                {isPaymentPending ? '결제 준비 중' : '결제하기'}
               </Button>
             ) : null}
           </div>

--- a/src/components/consumer/mypage/MypageReservationCard.tsx
+++ b/src/components/consumer/mypage/MypageReservationCard.tsx
@@ -81,6 +81,7 @@ export function MypageReservationCard({
   const { openPayment, isPending: isPaymentPending } = usePayment();
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
   const [isPickupCodeModalOpen, setIsPickupCodeModalOpen] = useState(false);
+  const [paymentErrorMessage, setPaymentErrorMessage] = useState('');
   const displayGroup = statusDisplayMap[reservation.status];
   const status = statusStyles[displayGroup];
   const isPickupCodeAvailable =
@@ -112,10 +113,16 @@ export function MypageReservationCard({
   };
 
   const handleOpenPayment = async () => {
-    await openPayment({
-      orderNumber: reservation.orderNumber,
-      orderName: reservationTitle,
-    });
+    setPaymentErrorMessage('');
+
+    try {
+      await openPayment({
+        orderNumber: reservation.orderNumber,
+        orderName: reservationTitle,
+      });
+    } catch {
+      setPaymentErrorMessage('결제를 시작하지 못했습니다. 다시 시도해 주세요.');
+    }
   };
 
   return (
@@ -192,13 +199,18 @@ export function MypageReservationCard({
                 color="primary"
                 disabled={isPaymentPending}
                 className="h-12 min-w-32 px-5 text-sm"
-                onClick={() => void handleOpenPayment()}
+                onClick={handleOpenPayment}
               >
                 {isPaymentPending ? '결제 준비 중' : '결제하기'}
               </Button>
             ) : null}
           </div>
         </div>
+        {paymentErrorMessage ? (
+          <p role="alert" className="mt-3 text-right text-sm text-red-500">
+            {paymentErrorMessage}
+          </p>
+        ) : null}
       </article>
 
       <MypageReservationDetailModal

--- a/src/components/consumer/order/OrderCheckoutPanel.tsx
+++ b/src/components/consumer/order/OrderCheckoutPanel.tsx
@@ -6,7 +6,7 @@ import { useState, type ReactNode } from 'react';
 import type { ProductDetail } from '@/types/product';
 import {
   formatPickupDateLabel,
-  formatPickupTime,
+  isPastPickupTimeSlot,
   type PickupTimeOption,
 } from '@/lib/formatPickupTime';
 import { useCreateOrder } from '@/hooks/orders/useCreateOrder';
@@ -19,7 +19,7 @@ interface OrderCheckoutPanelProps {
   product: ProductDetail;
   quantity: number;
   finalPaymentPrice: number;
-  initialPickupTime?: PickupTimeOption;
+  initialPickupTime: PickupTimeOption | null;
 }
 
 type OrderInfoBlockProps =
@@ -42,20 +42,6 @@ function getPickupPlace(product: ProductDetail) {
   return product.store.addressDetail
     ? `${product.store.address} ${product.store.addressDetail}`
     : product.store.address;
-}
-
-function createDefaultPickupTimeOption(
-  pickupStartTime: string,
-  pickupEndTime: string
-): PickupTimeOption {
-  const startAt = formatPickupTime(pickupStartTime);
-  const endAt = formatPickupTime(pickupEndTime);
-
-  return {
-    label: `${startAt}~${endAt}`,
-    startAt,
-    endAt,
-  };
 }
 
 function createPickupAt(
@@ -114,20 +100,41 @@ export function OrderCheckoutPanel({
     product.pickupStartTime,
     referenceNow
   );
-  const [pickupTime, setPickupTime] = useState(
-    () =>
-      initialPickupTime ??
-      createDefaultPickupTimeOption(
-        product.pickupStartTime,
-        product.pickupEndTime
-      )
+  const [pickupTime, setPickupTime] = useState<PickupTimeOption | null>(
+    initialPickupTime
   );
+  const [validationErrorMessage, setValidationErrorMessage] = useState('');
   const [isPickupTimeModalOpen, setIsPickupTimeModalOpen] = useState(false);
   const handleOpenPickupTimeModal = () => {
     setReferenceNow(new Date());
     setIsPickupTimeModalOpen(true);
   };
   const handlePaymentButtonClick = async () => {
+    setValidationErrorMessage('');
+
+    if (quantity <= 0) {
+      setValidationErrorMessage('결제 가능한 수량이 없습니다.');
+      return;
+    }
+
+    if (pickupTime === null) {
+      setValidationErrorMessage('픽업 시간을 선택해 주세요.');
+      return;
+    }
+
+    if (
+      isPastPickupTimeSlot(
+        pickupTime.startAt,
+        product.pickupStartTime,
+        new Date()
+      )
+    ) {
+      setValidationErrorMessage(
+        '이미 지난 픽업 시간입니다. 다시 선택해 주세요.'
+      );
+      return;
+    }
+
     const pickupAt = createPickupAt(product.pickupStartTime, pickupTime);
 
     if (pickupAt === null) {
@@ -150,8 +157,12 @@ export function OrderCheckoutPanel({
     }
   };
   const isSubmitting = createOrderMutation.isPending || isPaymentPending;
+  const isPaymentButtonDisabled =
+    isSubmitting || quantity <= 0 || pickupTime === null;
   const paymentErrorMessage =
-    createOrderMutation.error?.message ?? paymentError?.message;
+    validationErrorMessage ||
+    createOrderMutation.error?.message ||
+    paymentError?.message;
 
   return (
     <>
@@ -173,8 +184,15 @@ export function OrderCheckoutPanel({
           onAction={handleOpenPickupTimeModal}
         >
           <p className="font-medium text-gray-900">
-            {pickupDateLabel ? `${pickupDateLabel} ${pickupTime.label}` : '-'}
+            {pickupDateLabel && pickupTime
+              ? `${pickupDateLabel} ${pickupTime.label}`
+              : '픽업 시간을 선택해 주세요.'}
           </p>
+          {pickupTime === null ? (
+            <p className="mt-2 text-sm text-red-500">
+              선택 가능한 픽업 시간을 다시 선택해 주세요.
+            </p>
+          ) : null}
         </OrderInfoBlock>
 
         <OrderInfoBlock
@@ -195,7 +213,7 @@ export function OrderCheckoutPanel({
           </div>
 
           <Button
-            disabled={isSubmitting}
+            disabled={isPaymentButtonDisabled}
             className="w-full py-4 text-lg font-bold"
             onClick={handlePaymentButtonClick}
           >
@@ -206,7 +224,7 @@ export function OrderCheckoutPanel({
 
           {paymentErrorMessage ? (
             <p role="alert" className="mt-3 text-center text-sm text-red-500">
-              결제를 시작하지 못했습니다. 다시 시도해 주세요.
+              {paymentErrorMessage}
             </p>
           ) : null}
 

--- a/src/components/consumer/order/OrderCheckoutPanel.tsx
+++ b/src/components/consumer/order/OrderCheckoutPanel.tsx
@@ -3,7 +3,7 @@
 import { Clock, CreditCard, MapPin } from 'lucide-react';
 import { useState, type ReactNode } from 'react';
 
-import type { ProductDetailResponse } from '@/contracts/product';
+import type { ProductDetail } from '@/types/product';
 import {
   formatPickupDateLabel,
   formatPickupTime,
@@ -16,7 +16,7 @@ import { Button } from '@/components/common';
 import { PickupTimeChangeModal } from './PickupTimeChangeModal';
 
 interface OrderCheckoutPanelProps {
-  product: ProductDetailResponse;
+  product: ProductDetail;
   quantity: number;
   finalPaymentPrice: number;
   initialPickupTime?: PickupTimeOption;
@@ -38,7 +38,7 @@ type OrderInfoBlockProps =
       children: ReactNode;
     };
 
-function getPickupPlace(product: ProductDetailResponse) {
+function getPickupPlace(product: ProductDetail) {
   return product.store.addressDetail
     ? `${product.store.address} ${product.store.addressDetail}`
     : product.store.address;

--- a/src/components/consumer/order/OrderPageContainer.tsx
+++ b/src/components/consumer/order/OrderPageContainer.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import type { PickupTimeOption } from '@/lib/formatPickupTime';
+import {
+  createPickupTimeOptions,
+  formatPickupTime,
+  isPastPickupTimeSlot,
+} from '@/lib/formatPickupTime';
+import { useProduct } from '@/hooks/products/useProduct';
+import { Footer } from '@/components/common';
+import { ConsumerHeader } from '@/components/consumer/ConsumerHeader';
+
+import { OrderCheckoutPanel } from './OrderCheckoutPanel';
+import { OrderProductSummary } from './OrderProductSummary';
+import { OrderProgressSteps } from './OrderProgressSteps';
+
+interface OrderPageContainerProps {
+  productId: string;
+  searchParams: {
+    quantity?: string | string[];
+    pickupStart?: string | string[];
+    pickupEnd?: string | string[];
+  };
+}
+
+const SERVICE_FEE = 0;
+
+function getSearchParamValue(value?: string | string[]) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function getInitialQuantity(value: string | undefined, availableStock: number) {
+  if (availableStock <= 0) {
+    return 0;
+  }
+
+  const quantity = Number(value);
+
+  if (!Number.isInteger(quantity) || quantity < 1) {
+    return 1;
+  }
+
+  return Math.min(quantity, availableStock);
+}
+
+function getDefaultPickupTimeOption(
+  pickupStartTime: string,
+  pickupEndTime: string
+): PickupTimeOption {
+  const startAt = formatPickupTime(pickupStartTime);
+  const endAt = formatPickupTime(pickupEndTime);
+
+  return {
+    label: `${startAt}~${endAt}`,
+    startAt,
+    endAt,
+  };
+}
+
+function getInitialPickupTime({
+  pickupStartTime,
+  pickupEndTime,
+  pickupStart,
+  pickupEnd,
+}: {
+  pickupStartTime: string;
+  pickupEndTime: string;
+  pickupStart?: string;
+  pickupEnd?: string;
+}) {
+  const now = new Date();
+  const pickupTimeOptions = createPickupTimeOptions(
+    pickupStartTime,
+    pickupEndTime
+  );
+  const matchedPickupTime = pickupTimeOptions.find(
+    (option) => option.startAt === pickupStart && option.endAt === pickupEnd
+  );
+
+  if (
+    matchedPickupTime &&
+    !isPastPickupTimeSlot(matchedPickupTime.startAt, pickupStartTime, now)
+  ) {
+    return matchedPickupTime;
+  }
+
+  const firstAvailablePickupTime = pickupTimeOptions.find(
+    (option) => !isPastPickupTimeSlot(option.startAt, pickupStartTime, now)
+  );
+
+  return (
+    firstAvailablePickupTime ??
+    getDefaultPickupTimeOption(pickupStartTime, pickupEndTime)
+  );
+}
+
+export function OrderPageContainer({
+  productId,
+  searchParams,
+}: OrderPageContainerProps) {
+  const { data: product, isError, isLoading } = useProduct(productId);
+
+  if (isLoading) {
+    return (
+      <div className="bg-white">
+        <ConsumerHeader />
+        <main className="flex min-h-screen items-center justify-center bg-white">
+          <p
+            role="status"
+            aria-live="polite"
+            className="text-sm font-medium text-gray-500"
+          >
+            주문 정보를 불러오는 중입니다.
+          </p>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  if (isError || !product) {
+    return (
+      <div className="bg-white">
+        <ConsumerHeader />
+        <main className="flex min-h-screen items-center justify-center bg-white">
+          <p
+            role="alert"
+            aria-live="assertive"
+            className="text-sm font-medium text-gray-500"
+          >
+            주문할 상품 정보를 불러오지 못했습니다.
+          </p>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  const quantity = getInitialQuantity(
+    getSearchParamValue(searchParams.quantity),
+    product.availableStock
+  );
+  const initialPickupTime = getInitialPickupTime({
+    pickupStartTime: product.pickupStartTime,
+    pickupEndTime: product.pickupEndTime,
+    pickupStart: getSearchParamValue(searchParams.pickupStart),
+    pickupEnd: getSearchParamValue(searchParams.pickupEnd),
+  });
+  const productTotalPrice = product.discountPrice * quantity;
+  const originalTotalPrice = product.originalPrice * quantity;
+  const discountAmount = originalTotalPrice - productTotalPrice;
+  const finalPaymentPrice = productTotalPrice + SERVICE_FEE;
+
+  return (
+    <div className="bg-white">
+      <ConsumerHeader />
+
+      <main className="min-h-screen bg-white">
+        <section className="mx-auto max-w-450 px-6 py-10">
+          <h1 className="text-3xl font-bold text-gray-900">주문/결제</h1>
+
+          <div className="mt-10 grid gap-10 lg:grid-cols-[minmax(0,1fr)_440px]">
+            <div className="space-y-8">
+              <OrderProgressSteps currentStep="order" />
+
+              <OrderProductSummary
+                product={product}
+                quantity={quantity}
+                serviceFee={SERVICE_FEE}
+                productTotalPrice={productTotalPrice}
+                discountAmount={discountAmount}
+                finalPaymentPrice={finalPaymentPrice}
+              />
+            </div>
+
+            <aside className="lg:sticky lg:top-24 lg:self-start">
+              <OrderCheckoutPanel
+                product={product}
+                quantity={quantity}
+                finalPaymentPrice={finalPaymentPrice}
+                initialPickupTime={initialPickupTime}
+              />
+            </aside>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/consumer/order/OrderPageContainer.tsx
+++ b/src/components/consumer/order/OrderPageContainer.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import type { PickupTimeOption } from '@/lib/formatPickupTime';
 import {
   createPickupTimeOptions,
-  formatPickupTime,
   isPastPickupTimeSlot,
 } from '@/lib/formatPickupTime';
 import { useProduct } from '@/hooks/products/useProduct';
@@ -43,20 +41,6 @@ function getInitialQuantity(value: string | undefined, availableStock: number) {
   return Math.min(quantity, availableStock);
 }
 
-function getDefaultPickupTimeOption(
-  pickupStartTime: string,
-  pickupEndTime: string
-): PickupTimeOption {
-  const startAt = formatPickupTime(pickupStartTime);
-  const endAt = formatPickupTime(pickupEndTime);
-
-  return {
-    label: `${startAt}~${endAt}`,
-    startAt,
-    endAt,
-  };
-}
-
 function getInitialPickupTime({
   pickupStartTime,
   pickupEndTime,
@@ -84,14 +68,7 @@ function getInitialPickupTime({
     return matchedPickupTime;
   }
 
-  const firstAvailablePickupTime = pickupTimeOptions.find(
-    (option) => !isPastPickupTimeSlot(option.startAt, pickupStartTime, now)
-  );
-
-  return (
-    firstAvailablePickupTime ??
-    getDefaultPickupTimeOption(pickupStartTime, pickupEndTime)
-  );
+  return null;
 }
 
 export function OrderPageContainer({

--- a/src/components/consumer/order/OrderProductSummary.tsx
+++ b/src/components/consumer/order/OrderProductSummary.tsx
@@ -1,10 +1,10 @@
 import { Minus, Plus, ShieldCheck } from 'lucide-react';
 import Image from 'next/image';
 
-import type { ProductDetailResponse } from '@/contracts/product';
+import type { ProductDetail } from '@/types/product';
 
 interface OrderProductSummaryProps {
-  product: ProductDetailResponse;
+  product: ProductDetail;
   quantity: number;
   serviceFee: number;
   productTotalPrice: number;

--- a/src/components/consumer/order/PickupTimeChangeModal.tsx
+++ b/src/components/consumer/order/PickupTimeChangeModal.tsx
@@ -11,7 +11,7 @@ import { Button, Modal } from '@/components/common';
 
 interface PickupTimeChangeModalProps {
   isOpen: boolean;
-  selectedPickupTime: PickupTimeOption;
+  selectedPickupTime: PickupTimeOption | null;
   pickupStartTime: string;
   pickupEndTime: string;
   referenceNow: Date;
@@ -33,6 +33,7 @@ export function PickupTimeChangeModal({
     pickupEndTime
   );
   const initialDraftPickupTime =
+    selectedPickupTime !== null &&
     pickupTimeOptions.find(
       (option) => option.startAt === selectedPickupTime.startAt
     ) &&


### PR DESCRIPTION
## 📌 작업 내용

- 상품 상세 페이지에서 선택한 픽업 시간과 수량을 주문/결제 페이지로 전달하도록 연결했습니다.
- 주문/결제 페이지에서 전달받은 예약 정보를 기반으로 상품 요약, 픽업 시간, 수량, 결제 금액을 표시하도록 수정했습니다.
- 결제 버튼 클릭 시 `usePayment` 흐름을 통해 결제 플로우로 진입하도록 연결했습니다.
- 메인 상품 카드 이미지가 API 이미지 값을 사용하고, 이미지가 없을 경우 `noimage.png`를 fallback으로 사용하도록 수정했습니다.

## 🔧 변경 사항

- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📂 주요 변경 파일

- `ProductReservationPanel.tsx`
- `OrderPageContainer.tsx`
- `OrderCheckoutPanel.tsx`
- `ProductCard.tsx`

## 🧪 테스트 방법

- 상품 상세 페이지 접속
- 픽업 시간과 수량 선택
- `담기` 버튼 클릭
- `/order/[productId]` 주문/결제 페이지 이동 확인
- 주문 페이지에서 선택한 시간/수량/금액 반영 확인
- 결제하기 버튼 클릭 시 결제 흐름 진입 확인
- 메인 페이지 상품 카드에서 API 이미지 또는 `noimage.png` fallback 확인

## 📸 스크린샷

- UI 변경 사항이 있어 PR에 상품 상세 → 주문/결제 페이지 이동 화면 첨부 예정

## 🔗 관련 이슈

- close #149
