### PR TITLE
fix: headlessui-focus-visible을 focus-visible로 변경

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,5 @@
 @import 'tailwindcss';
 
-@custom-variant headlessui-focus-visible ([data-headlessui-focus-visible] &);
-
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/src/components/common/Dropdown/Dropdown.tsx
+++ b/src/components/common/Dropdown/Dropdown.tsx
@@ -46,7 +46,7 @@ interface ActionDropdownProps extends BaseDropdownProps {
 type DropdownProps = SelectDropdownProps | ActionDropdownProps;
 
 const TRIGGER_CLASS_NAME =
-  'group headlessui-focus-visible:outline-none headlessui-focus-visible:ring-2 headlessui-focus-visible:ring-offset-2 inline-flex items-center justify-center gap-2 rounded-sm border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-900 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400';
+  'group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 inline-flex items-center justify-center gap-2 rounded-sm border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-900 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400';
 
 const DROPDOWN_ITEMS_CLASS_NAME =
   'z-10 mt-2 min-w-(--button-width) w-max rounded-md border border-gray-200 bg-white p-1 shadow-lg focus:outline-none';

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -107,22 +107,34 @@ function UserMenu({
   }
 
   return (
-    <div className="relative">
-      <Menu>
+    <div className="relative inline-block text-left">
+      <Menu as="div" className="relative inline-block text-left">
         <MenuButton className="group focus-visible:ring-primary-500 flex items-center gap-2 rounded-sm px-4 py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2">
           <ProfileAvatar user={user} />
           {user.name}
-          <ChevronDownIcon className="h-4 w-4 group-data-active:hidden" />
-          <ChevronUpIcon className="hidden h-4 w-4 group-data-active:block" />
+          <ChevronDownIcon
+            aria-hidden="true"
+            focusable="false"
+            className="h-4 w-4 group-data-open:hidden"
+          />
+          <ChevronUpIcon
+            aria-hidden="true"
+            focusable="false"
+            className="hidden h-4 w-4 group-data-open:block"
+          />
         </MenuButton>
-        <MenuItems className="absolute right-0 z-50 mt-2 w-48 rounded border border-gray-200 bg-white shadow-lg focus:outline-none">
+
+        <MenuItems
+          anchor="bottom end"
+          className="z-50 mt-2 w-48 rounded-md border border-gray-200 bg-white p-1 shadow-lg focus:outline-none"
+        >
           {menuItems.map((item) =>
             item.type === 'link' ? (
               <MenuItem
                 key={item.label}
                 as={Link}
                 href={item.href}
-                className={`block px-4 py-2 hover:bg-gray-100 data-focus:bg-gray-100 ${item.className || ''}`}
+                className={`block rounded px-3 py-2 text-sm text-gray-700 data-focus:bg-gray-100 ${item.className || ''}`}
               >
                 {item.label}
               </MenuItem>
@@ -132,7 +144,7 @@ function UserMenu({
                 as="button"
                 type="button"
                 onClick={item.onClick}
-                className={`block w-full px-4 py-2 text-left hover:bg-gray-100 data-focus:bg-gray-100 ${item.className || ''}`}
+                className={`block w-full rounded px-3 py-2 text-left text-sm text-gray-700 data-focus:bg-gray-100 ${item.className || ''}`}
               >
                 {item.label}
               </MenuItem>

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -109,7 +109,7 @@ function UserMenu({
   return (
     <div className="relative">
       <Menu>
-        <MenuButton className="group headlessui-focus-visible:ring-2 headlessui-focus-visible:ring-primary-500 headlessui-focus-visible:ring-offset-2 flex items-center gap-2 rounded-sm px-4 py-2 focus:outline-none">
+        <MenuButton className="group focus-visible:ring-primary-500 flex items-center gap-2 rounded-sm px-4 py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2">
           <ProfileAvatar user={user} />
           {user.name}
           <ChevronDownIcon className="h-4 w-4 group-data-active:hidden" />

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -107,52 +107,50 @@ function UserMenu({
   }
 
   return (
-    <div className="relative inline-block text-left">
-      <Menu as="div" className="relative inline-block text-left">
-        <MenuButton className="group focus-visible:ring-primary-500 flex items-center gap-2 rounded-sm px-4 py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2">
-          <ProfileAvatar user={user} />
-          {user.name}
-          <ChevronDownIcon
-            aria-hidden="true"
-            focusable="false"
-            className="h-4 w-4 group-data-open:hidden"
-          />
-          <ChevronUpIcon
-            aria-hidden="true"
-            focusable="false"
-            className="hidden h-4 w-4 group-data-open:block"
-          />
-        </MenuButton>
+    <Menu as="div" className="relative inline-block text-left">
+      <MenuButton className="group focus-visible:ring-primary-500 flex items-center gap-2 rounded-sm px-4 py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2">
+        <ProfileAvatar user={user} />
+        {user.name}
+        <ChevronDownIcon
+          aria-hidden="true"
+          focusable="false"
+          className="h-4 w-4 group-data-open:hidden"
+        />
+        <ChevronUpIcon
+          aria-hidden="true"
+          focusable="false"
+          className="hidden h-4 w-4 group-data-open:block"
+        />
+      </MenuButton>
 
-        <MenuItems
-          anchor="bottom end"
-          className="z-50 mt-2 w-48 rounded-md border border-gray-200 bg-white p-1 shadow-lg focus:outline-none"
-        >
-          {menuItems.map((item) =>
-            item.type === 'link' ? (
-              <MenuItem
-                key={item.label}
-                as={Link}
-                href={item.href}
-                className={`block rounded px-3 py-2 text-sm text-gray-700 data-focus:bg-gray-100 ${item.className || ''}`}
-              >
-                {item.label}
-              </MenuItem>
-            ) : (
-              <MenuItem
-                key={item.label}
-                as="button"
-                type="button"
-                onClick={item.onClick}
-                className={`block w-full rounded px-3 py-2 text-left text-sm text-gray-700 data-focus:bg-gray-100 ${item.className || ''}`}
-              >
-                {item.label}
-              </MenuItem>
-            )
-          )}
-        </MenuItems>
-      </Menu>
-    </div>
+      <MenuItems
+        anchor="bottom end"
+        className="z-50 mt-2 w-48 rounded-md border border-gray-200 bg-white p-1 shadow-lg focus:outline-none"
+      >
+        {menuItems.map((item) =>
+          item.type === 'link' ? (
+            <MenuItem
+              key={item.label}
+              as={Link}
+              href={item.href}
+              className={`block rounded px-3 py-2 text-sm text-gray-700 data-focus:bg-gray-100 ${item.className || ''}`}
+            >
+              {item.label}
+            </MenuItem>
+          ) : (
+            <MenuItem
+              key={item.label}
+              as="button"
+              type="button"
+              onClick={item.onClick}
+              className={`block w-full rounded px-3 py-2 text-left text-sm text-gray-700 data-focus:bg-gray-100 ${item.className || ''}`}
+            >
+              {item.label}
+            </MenuItem>
+          )
+        )}
+      </MenuItems>
+    </Menu>
   );
 }
 


### PR DESCRIPTION
## 📌 작업 내용

- HeadlessUI 포커스 스타일 전역 전파 문제 수정
- Input 포커스 시 HeadlessUI 컴포넌트에 의도치 않은 focus 스타일이 함께 적용되는 문제를 수정

Task ID: #157 

## 🔧 변경 사항

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📚 문서/Task 반영

- [ ] 관련 `docs/*` 최신화 필요 여부 확인
- [ ] 필요한 문서 수정 반영 또는 후속 task/확인 필요로 기록
- [ ] `docs/tasks` 상태와 GitHub Issue 번호 갱신

## 📂 주요 변경 파일

- src/components/common/Dropdown/Dropdown.tsx
- src/components/common/Header/Header.tsx

## 🧪 테스트 방법

- /seller/products 페이지 접속
- 검색 Input 클릭
- 우측 상단 유저 메뉴 버튼 및 Dropdown 버튼에 focus 스타일 미적용 확인
- Tab 키로 포커스 이동 시 각 컴포넌트에만 focus 스타일 적용 확인

## 📸 스크린샷 (선택)



## 🔗 관련 이슈

- close #157
