### PR TITLE
Claude/Codex 스킬 추가

### DIFF
--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: create-issue
+description: PickMa docs/tasks의 task ID를 기준으로 GitHub issue template을 선택하고 temp/Txx-issue.md에 이슈 초안을 작성한다.
+argument-hint: 'task ID'
+---
+
+# 이슈 초안 생성
+
+PickMa task에서 GitHub Issue 초안을 만들 때 사용한다. 사용자가 "T02 이슈", "T02 issue 만들어줘"처럼 task ID를 주면 `docs/tasks/T02_*.md`를 원본 task로 읽고 `temp/T02-issue.md`를 생성 대상으로 해석한다.
+
+이 스킬은 temp 이슈 초안만 생성한다. GitHub Issue를 직접 만들지 않고, task 문서의 `GitHub Issue` 번호도 갱신하지 않는다.
+
+## 작업 흐름
+
+1. task ID를 파악한다. task ID가 없고 후보가 여러 개면 사용자에게 확인한다.
+2. `docs/tasks/README.md`와 `docs/tasks/Txx_*.md`를 읽어 제목, 우선순위, 상태, GitHub Issue 값, 분류, 사용자 흐름, 역할, 배경, 문제, 작업 내용, 관련 파일, 완료 기준을 확인한다.
+3. `.github/ISSUE_TEMPLATE/*.md`를 읽고 task 성격에 가장 맞는 template을 하나 선택한다.
+4. 생성 대상은 `temp/Txx-issue.md`로 둔다. 이미 있으면 덮어쓰기 전에 사용자에게 확인한다.
+5. 선택한 issue template의 frontmatter와 섹션 구조를 유지하되, task 문서에서 확인한 내용으로 본문을 채운다.
+6. 초안 앞부분에 선택 근거와 원본 task 경로를 짧게 남긴다. GitHub에 붙여 넣을 본문은 `## GitHub Issue Draft` 아래에 둔다.
+7. 최종 응답에서는 생성된 파일, 선택한 template, 실제 issue 생성 후 task 문서의 `GitHub Issue` 번호를 갱신해야 한다는 점만 간단히 알린다.
+
+## Template 선택 기준
+
+- `feature.md`: 새 사용자 기능, 화면, API endpoint, hook, user flow 구현이 중심인 task.
+- `bug.md`: 이미 동작해야 하는 기능의 깨짐, 회귀, 재현 가능한 오류 수정이 중심인 task.
+- `refactor.md`: public behavior 변경 없이 코드 구조, 타입, import, 호출 방식, 계층 구조를 개선하는 task.
+- `docs.md`: 정책, 설계, 기준 문서 작성/수정이 중심이고 code 변경이 없거나 보조적인 task.
+- `chore.md`: CI, 설정, tooling, repository 구조, 자산 정리, 개발 환경 정비처럼 기능/문서/리팩터링 중 하나로 보기 애매한 task.
+
+선택이 애매하면 task의 `분류`, `작업 내용`, `완료 기준`을 우선한다. 예를 들어 "정책 확정"과 문서화가 핵심이면 `docs.md`, 정책에 맞춘 구현이 핵심이면 `feature.md` 또는 `chore.md`를 고른다.
+
+## 초안 형식
+
+```markdown
+# Txx GitHub Issue Draft — {task 제목}
+
+- Task 문서: `docs/tasks/Txx_*.md`
+- 선택한 template: `.github/ISSUE_TEMPLATE/{template}.md`
+- 선택 근거: {짧은 이유}
+- GitHub Issue: 확인 필요 또는 `#N`
+
+## GitHub Issue Draft
+
+{선택한 template frontmatter와 본문}
+```
+
+## 작성 규칙
+
+- title frontmatter는 template prefix를 유지하고 task 제목을 붙인다. 예: `title: '[feat] 판매자 주문 관리 real API 연결'`
+- labels frontmatter는 template 값을 유지한다.
+- `Task ID:`에는 task ID만 쓴다.
+- 체크박스는 task의 `작업 내용`을 실행 가능한 항목으로 바꿔 작성한다.
+- `작업 위치`, `리팩토링 대상`, `발생 위치`, `참고` 등 template별 섹션에는 task의 관련 파일/영역과 문서 경로를 넣는다.
+- task에 없는 내용을 추측해서 확정하지 않는다. 필요한 경우 본문에 `확인 필요:`로 남긴다.
+- `temp/` 파일은 commit 대상에 포함하지 않는다.

--- a/.agents/skills/create-plan/SKILL.md
+++ b/.agents/skills/create-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-plan
-description: PickMa docs/tasks의 task를 기준으로 temp/Txx-plan.md 계획 문서를 생성한다. task 상태를 진행 중으로 갱신하고, 실행 가능한 작은 step과 검증 계획, GitHub issue 초안을 정리한다.
+description: PickMa docs/tasks의 task를 기준으로 temp/Txx-plan.md 계획 문서를 생성한다. task 상태를 진행 중으로 갱신하고, 실행 가능한 작은 step과 검증 계획을 정리한다.
 argument-hint: 'task ID와 계획할 작업 설명'
 ---
 
@@ -16,14 +16,13 @@ PickMa task 계획 문서를 만들 때 사용한다. 사용자가 "T02 계획"�
 2. `docs/tasks/README.md`와 `docs/tasks/Txx_*.md`를 읽어 목표, 범위, 우선순위, 선행 조건, 관련 파일을 확인한다.
 3. 생성 대상은 `temp/Txx-plan.md`로 둔다. 이미 있으면 덮어쓰기 전에 사용자에게 확인한다.
 4. task 문서와 `docs/tasks/README.md`의 해당 행 상태를 `진행 중`으로 갱신한다. 이미 다른 상태면 임의로 덮어쓰지 말고 사용자에게 확인한다.
-5. GitHub Issue가 `확인 필요`이면 task 성격에 맞는 기존 issue template을 선택해 `temp/Txx-issue.md` 초안을 작성한다. 별도 create-issue 스킬은 두지 않는다. issue를 직접 만들지는 않고, 최종 응답에서 생성 필요와 task 문서의 issue 번호 갱신 필요를 알린다.
-6. 작업 성격에 맞는 문서만 확인한다.
+5. 작업 성격에 맞는 문서만 확인한다.
    - 항상: `AGENTS.md`, `.codex/instructions/coding-style.md`, `.codex/instructions/implementation.md`
    - DB/API/Domain: `docs/system_architecture.md`, `docs/type_architecture.md`, `docs/domain.md`, `docs/api_spec.md`, 필요 시 `docs/erd.md`
    - 화면/사용자 흐름: `docs/prd.md`, 필요 시 `docs/ia.md`
-7. 현재 코드 상태를 필요한 만큼 확인해 이미 완료된 작업, 존재하는 파일, 충돌 가능성을 반영한다.
-8. task 범위를 커밋 가능한 작은 step으로 나눈다. 각 step에는 목적, 예상 변경 파일, 작업 내용, 검증, 커밋 기준을 포함한다.
-9. `temp/Txx-plan.md`를 작성한다.
+6. 현재 코드 상태를 필요한 만큼 확인해 이미 완료된 작업, 존재하는 파일, 충돌 가능성을 반영한다.
+7. task 범위를 커밋 가능한 작은 step으로 나눈다. 각 step에는 목적, 예상 변경 파일, 작업 내용, 검증, 커밋 기준을 포함한다.
+8. `temp/Txx-plan.md`를 작성한다.
 
 ## 계획 형식
 

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: create-issue
+description: PickMa docs/tasks의 task ID를 기준으로 GitHub issue template을 선택하고 temp/Txx-issue.md에 이슈 초안을 작성한다.
+argument-hint: 'task ID'
+---
+
+# 이슈 초안 생성
+
+PickMa task에서 GitHub Issue 초안을 만들 때 사용한다. 사용자가 "T02 이슈", "T02 issue 만들어줘"처럼 task ID를 주면 `docs/tasks/T02_*.md`를 원본 task로 읽고 `temp/T02-issue.md`를 생성 대상으로 해석한다.
+
+이 스킬은 temp 이슈 초안만 생성한다. GitHub Issue를 직접 만들지 않고, task 문서의 `GitHub Issue` 번호도 갱신하지 않는다.
+
+## 작업 흐름
+
+1. task ID를 파악한다. task ID가 없고 후보가 여러 개면 사용자에게 확인한다.
+2. `docs/tasks/README.md`와 `docs/tasks/Txx_*.md`를 읽어 제목, 우선순위, 상태, GitHub Issue 값, 분류, 사용자 흐름, 역할, 배경, 문제, 작업 내용, 관련 파일, 완료 기준을 확인한다.
+3. `.github/ISSUE_TEMPLATE/*.md`를 읽고 task 성격에 가장 맞는 template을 하나 선택한다.
+4. 생성 대상은 `temp/Txx-issue.md`로 둔다. 이미 있으면 덮어쓰기 전에 사용자에게 확인한다.
+5. 선택한 issue template의 frontmatter와 섹션 구조를 유지하되, task 문서에서 확인한 내용으로 본문을 채운다.
+6. 초안 앞부분에 선택 근거와 원본 task 경로를 짧게 남긴다. GitHub에 붙여 넣을 본문은 `## GitHub Issue Draft` 아래에 둔다.
+7. 최종 응답에서는 생성된 파일, 선택한 template, 실제 issue 생성 후 task 문서의 `GitHub Issue` 번호를 갱신해야 한다는 점만 간단히 알린다.
+
+## Template 선택 기준
+
+- `feature.md`: 새 사용자 기능, 화면, API endpoint, hook, user flow 구현이 중심인 task.
+- `bug.md`: 이미 동작해야 하는 기능의 깨짐, 회귀, 재현 가능한 오류 수정이 중심인 task.
+- `refactor.md`: public behavior 변경 없이 코드 구조, 타입, import, 호출 방식, 계층 구조를 개선하는 task.
+- `docs.md`: 정책, 설계, 기준 문서 작성/수정이 중심이고 code 변경이 없거나 보조적인 task.
+- `chore.md`: CI, 설정, tooling, repository 구조, 자산 정리, 개발 환경 정비처럼 기능/문서/리팩터링 중 하나로 보기 애매한 task.
+
+선택이 애매하면 task의 `분류`, `작업 내용`, `완료 기준`을 우선한다. 예를 들어 "정책 확정"과 문서화가 핵심이면 `docs.md`, 정책에 맞춘 구현이 핵심이면 `feature.md` 또는 `chore.md`를 고른다.
+
+## 초안 형식
+
+```markdown
+# Txx GitHub Issue Draft — {task 제목}
+
+- Task 문서: `docs/tasks/Txx_*.md`
+- 선택한 template: `.github/ISSUE_TEMPLATE/{template}.md`
+- 선택 근거: {짧은 이유}
+- GitHub Issue: 확인 필요 또는 `#N`
+
+## GitHub Issue Draft
+
+{선택한 template frontmatter와 본문}
+```
+
+## 작성 규칙
+
+- title frontmatter는 template prefix를 유지하고 task 제목을 붙인다. 예: `title: '[feat] 판매자 주문 관리 real API 연결'`
+- labels frontmatter는 template 값을 유지한다.
+- `Task ID:`에는 task ID만 쓴다.
+- 체크박스는 task의 `작업 내용`을 실행 가능한 항목으로 바꿔 작성한다.
+- `작업 위치`, `리팩토링 대상`, `발생 위치`, `참고` 등 template별 섹션에는 task의 관련 파일/영역과 문서 경로를 넣는다.
+- task에 없는 내용을 추측해서 확정하지 않는다. 필요한 경우 본문에 `확인 필요:`로 남긴다.
+- `temp/` 파일은 commit 대상에 포함하지 않는다.

--- a/.claude/skills/create-plan/SKILL.md
+++ b/.claude/skills/create-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-plan
-description: PickMa docs/tasks의 task를 기준으로 temp/Txx-plan.md 계획 문서를 생성한다. task 상태를 진행 중으로 갱신하고, 실행 가능한 작은 step과 검증 계획, GitHub issue 초안을 정리한다.
+description: PickMa docs/tasks의 task를 기준으로 temp/Txx-plan.md 계획 문서를 생성한다. task 상태를 진행 중으로 갱신하고, 실행 가능한 작은 step과 검증 계획을 정리한다.
 argument-hint: 'task ID와 계획할 작업 설명'
 ---
 
@@ -16,14 +16,13 @@ PickMa task 계획 문서를 만들 때 사용한다. 사용자가 "T02 계획"�
 2. `docs/tasks/README.md`와 `docs/tasks/Txx_*.md`를 읽어 목표, 범위, 우선순위, 선행 조건, 관련 파일을 확인한다.
 3. 생성 대상은 `temp/Txx-plan.md`로 둔다. 이미 있으면 덮어쓰기 전에 사용자에게 확인한다.
 4. task 문서와 `docs/tasks/README.md`의 해당 행 상태를 `진행 중`으로 갱신한다. 이미 다른 상태면 임의로 덮어쓰지 말고 사용자에게 확인한다.
-5. GitHub Issue가 `확인 필요`이면 task 성격에 맞는 기존 issue template을 선택해 `temp/Txx-issue.md` 초안을 작성한다. 별도 create-issue 스킬은 두지 않는다. issue를 직접 만들지는 않고, 최종 응답에서 생성 필요와 task 문서의 issue 번호 갱신 필요를 알린다.
-6. 작업 성격에 맞는 문서만 확인한다.
+5. 작업 성격에 맞는 문서만 확인한다.
    - 항상: `CLAUDE.md`, `.claude/rules/coding-style.md`, `.claude/rules/implementation.md`
    - DB/API/Domain: `docs/system_architecture.md`, `docs/type_architecture.md`, `docs/domain.md`, `docs/api_spec.md`, 필요 시 `docs/erd.md`
    - 화면/사용자 흐름: `docs/prd.md`, 필요 시 `docs/ia.md`
-7. 현재 코드 상태를 필요한 만큼 확인해 이미 완료된 작업, 존재하는 파일, 충돌 가능성을 반영한다.
-8. task 범위를 커밋 가능한 작은 step으로 나눈다. 각 step에는 목적, 예상 변경 파일, 작업 내용, 검증, 커밋 기준을 포함한다.
-9. `temp/Txx-plan.md`를 작성한다.
+6. 현재 코드 상태를 필요한 만큼 확인해 이미 완료된 작업, 존재하는 파일, 충돌 가능성을 반영한다.
+7. task 범위를 커밋 가능한 작은 step으로 나눈다. 각 step에는 목적, 예상 변경 파일, 작업 내용, 검증, 커밋 기준을 포함한다.
+8. `temp/Txx-plan.md`를 작성한다.
 
 ## 계획 형식
 

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: review-plan
+description: PickMa temp/Txx-plan.md 계획 문서를 현재 문서, 코드, 실행 흐름 기준으로 검토하고, 수정 전 사용자 결정을 받는다.
+argument-hint: 'task ID 또는 temp/Txx-plan.md 파일 경로'
+---
+
+# 계획 리뷰
+
+PickMa task 계획을 실행 전에 검토하거나 보강할 때 사용한다. 사용자가 "T02 계획 검토"처럼 task ID만 말하면 `temp/T02-plan.md`로 해석한다.
+
+이 스킬은 먼저 계획 문서를 검토해 항목별로 문제, 영향, 권장 조치를 설명한다. 사용자가 반영할 항목을 결정하기 전에는 계획 문서를 수정하지 않는다. production code는 수정하지 않는다.
+
+## 작업 흐름
+
+1. 대상 계획 문서를 읽는다. task ID만 있으면 `temp/Txx-plan.md`를 연다.
+2. `docs/tasks/README.md`와 `docs/tasks/Txx_*.md`를 함께 읽어 task 목표, 선행 조건, scope, GitHub Issue를 확인한다.
+3. 작업 성격에 맞는 문서만 확인한다.
+   - 항상: `CLAUDE.md`, `.claude/rules/coding-style.md`, `.claude/rules/implementation.md`
+   - DB/API/Domain: `docs/system_architecture.md`, `docs/type_architecture.md`, `docs/domain.md`, `docs/api_spec.md`, 필요 시 `docs/erd.md`
+   - 화면/사용자 흐름: `docs/prd.md`, 필요 시 `docs/ia.md`
+4. 현재 코드를 필요한 만큼 확인해 계획의 파일 경로, 이미 완료된 작업, 충돌 가능성, 누락된 의존성을 검증한다.
+5. 수정하지 말고 검토 결과를 먼저 제시한다. 각 항목에는 현재 내용, 문제, 영향, 권장 조치, 반영 여부 선택지를 포함한다.
+6. 사용자가 반영할 항목을 결정하면, 승인된 항목만 계획 파일에 수정한다.
+7. 최종 응답에는 반영한 내용, 반영하지 않은 항목, 남은 질문, 실행 준비 여부를 짧게 요약한다.
+
+## 계획 구조 확인
+
+- 제목: `# Txx 계획 — {제목}`
+- `목표`, `배경`, `범위`, `실행 단계`, `영향 파일`, `확인 필요 사항`, `검증 계획`, `완료 기준`, `리뷰 산출물`
+- `리뷰 산출물`: `temp/Txx-code-review.md`
+
+## 실행 가능성 확인
+
+- `execute-plan`이 step별 승인/구현/검증/커밋을 할 수 있을 만큼 단계가 작고 명확한가.
+- 각 step에 목적, 예상 변경 파일, 작업 내용, 검증, 커밋 기준이 있는가.
+- 포함/제외 범위가 명확하고 인접 task 작업이 섞이지 않았는가.
+- blocker와 비차단 확인 사항이 구분되는가.
+- 검증 계획이 targeted test, lint/test/storybook, 수동 검증을 현실적으로 다루는가.
+
+## 규칙
+
+- 사용자 승인 전에는 어떤 파일도 수정하지 않는다.
+- 승인 후에도 계획 파일 외에는 수정하지 않는다.
+- 불확실한 scope를 조용히 제거하지 않는다. `확인 필요 사항` 또는 later task로 명시한다.
+- 이미 완료된 작업은 현재 상태에 맞게 배경이나 제외 범위로 이동한다.


### PR DESCRIPTION
## 📌 작업 내용

- Claude와 Codex에 create-issue 스킬을 추가하였습니다.
- Claude에 Codex의 review-plan 스킬을 추가하였습니다

Task ID:

## 🔧 변경 사항

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📚 문서/Task 반영

- [ ] 관련 `docs/*` 최신화 필요 여부 확인
- [ ] 필요한 문서 수정 반영 또는 후속 task/확인 필요로 기록
- [ ] `docs/tasks` 상태와 GitHub Issue 번호 갱신

## 📂 주요 변경 파일

- `.claude/skills/create-issue/SKILL.md`
- `.agents/skills/create-issue/SKILL.md`
- `.claude/skills/review-plan/SKILL.md`

## 🔗 관련 이슈

- closes #159 
