### PR TITLE
chore: 기본 CI 파이프라인 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Lint, typecheck, and test
@@ -33,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+  push:
+    branches:
+      - dev
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Lint, typecheck, and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      API_MOCK_ENABLED: 'true'
+      PAYMENT_MOCK: 'true'
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+      NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54321
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: test-publishable-key
+      SUPABASE_SECRET_KEY: test-secret-key
+      NEXT_PUBLIC_TOSS_CLIENT_KEY: test_ck_ci
+      TOSS_SECRET_KEY: test_sk_ci
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Unit tests
+        run: npm run test

--- a/docs/system_architecture.md
+++ b/docs/system_architecture.md
@@ -476,7 +476,42 @@ src/
 
 ---
 
-## 11. 보안 고려사항
+## 11. CI/CD
+
+GitHub Actions 기본 CI는 PR과 `dev`/`main` push에서 실행한다.
+
+초기 CI job은 다음 명령을 순서대로 실행한다.
+
+```bash
+npm ci
+npx playwright install --with-deps chromium
+npm run lint
+npm run typecheck
+npm run test
+```
+
+`npm run test`에는 Storybook/Vitest browser project가 포함되므로 Chromium browser를 설치한다. E2E job은 T23 완료 후 별도 workflow 또는 job으로 분리하며, 이 기본 CI job에는 포함하지 않는다.
+
+CI 환경 변수는 실제 외부 서비스에 연결하지 않는 mock/test 값을 사용한다.
+
+| 변수명                                 | CI 기본값                | 비고                          |
+| -------------------------------------- | ------------------------ | ----------------------------- |
+| `API_MOCK_ENABLED`                     | `true`                   | Route Handler mock mode       |
+| `PAYMENT_MOCK`                         | `true`                   | Toss API 미호출               |
+| `NEXT_PUBLIC_APP_URL`                  | `http://localhost:3000`  | 서버 API origin 고정용        |
+| `NEXT_PUBLIC_SUPABASE_URL`             | `http://127.0.0.1:54321` | test placeholder              |
+| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | `test-publishable-key`   | test placeholder              |
+| `SUPABASE_SECRET_KEY`                  | `test-secret-key`        | test placeholder, secret 아님 |
+| `NEXT_PUBLIC_TOSS_CLIENT_KEY`          | `test_ck_ci`             | test placeholder              |
+| `TOSS_SECRET_KEY`                      | `test_sk_ci`             | test placeholder, secret 아님 |
+
+`npm run build`는 초기 CI 필수 job에 포함하지 않고, 팀 결정 후 별도 job으로 추가한다.
+
+Branch protection은 `dev` 대상 PR에서 `CI / Lint, typecheck, and test` 통과를 필수 check로 설정한다. 저장소 설정은 GitHub UI에서 관리한다.
+
+---
+
+## 12. 보안 고려사항
 
 | 항목        | 대응 방안                                                                        |
 | ----------- | -------------------------------------------------------------------------------- |
@@ -489,7 +524,7 @@ src/
 
 ---
 
-## 12. 확장 포인트
+## 13. 확장 포인트
 
 | 기능        | 확장 방안                 |
 | ----------- | ------------------------- |

--- a/docs/system_architecture.md
+++ b/docs/system_architecture.md
@@ -536,9 +536,9 @@ Branch protection은 `dev` 대상 PR에서 `CI / Lint, typecheck, and test` 통�
 
 ---
 
-## 13. Storage lifecycle 정책
+## 14. Storage lifecycle 정책
 
-### 13.1 Bucket 목록
+### 14.1 Bucket 목록
 
 | Bucket                         | 접근    | 민감도 | cleanup 우선순위 |
 | ------------------------------ | ------- | ------ | ---------------- |
@@ -554,7 +554,7 @@ Branch protection은 `dev` 대상 PR에서 `CI / Lint, typecheck, and test` 통�
 - product-images: `{storeId}/{uploadId}/{fileName}`
 - profile-images: `{userId}/{uploadId}/{fileName}`
 
-### 13.2 Orphan cleanup 방식
+### 14.2 Orphan cleanup 방식
 
 클라이언트 best-effort와 서버 주기적 orphan 스캔의 hybrid 방식을 채택한다.
 
@@ -570,7 +570,7 @@ Branch protection은 `dev` 대상 PR에서 `CI / Lint, typecheck, and test` 통�
 - endpoint: `GET /api/cron/storage-cleanup`
 - 인증: `Authorization: Bearer ${CRON_SECRET}` (서버 전용 환경 변수, client bundle 미노출). 인증 실패 시 401 반환.
 
-### 13.3 보관 기간 정책
+### 14.3 보관 기간 정책
 
 개인정보보호법의 "처리목적 달성 후 지체 없이 파기" 원칙을 기준으로 한다. 세부 기간은 법무/운영 확인 후 최종 확정한다.
 
@@ -585,7 +585,7 @@ Branch protection은 `dev` 대상 PR에서 `CI / Lint, typecheck, and test` 통�
 | 철회 / 만료                               | 지체 없이 삭제 대상                              |
 | 분쟁 / 법령 대응 필요                     | 원본 파일 장기 보관 금지, 최소 메타데이터만 보존 |
 
-### 13.4 삭제 트리거 및 주체
+### 14.4 삭제 트리거 및 주체
 
 | 트리거             | 주체               | 구현 시점 |
 | ------------------ | ------------------ | --------- |
@@ -600,7 +600,7 @@ Branch protection은 `dev` 대상 PR에서 `CI / Lint, typecheck, and test` 통�
 - 클라이언트 cleanup: 본인 인증(`requireActiveUser()`) 후 `DELETE /api/files`. userId prefix로 소유권 검증.
 - 서버 cleanup: service role client (RLS bypass).
 
-### 13.5 향후 재검토 사항
+### 14.5 향후 재검토 사항
 
 - Toss 지급대행/KYC 책임 범위 확정 시 서류 보관 의무 재검토. 세부 정책은 T44에서 결정한다.
 - 분쟁 대응에 필요한 최소 메타데이터 범위 확인 (운영/CS 정책).

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -48,7 +48,7 @@ PickMa 심화 프로젝트 task의 공유 기준 문서다. `temp/`는 로컬 �
 | T21 | 지도 기반 조회 및 거리순 정렬                     | P2       | 진행 전 | 확인 필요    | T08, T05           | [T21_map_based_search_distance_sort.md](T21_map_based_search_distance_sort.md)                                   |
 | T22 | 실시간 알림 기반 설계 및 1차 구현                 | P2       | 진행 전 | 확인 필요    | T11                | [T22_realtime_notification_foundation.md](T22_realtime_notification_foundation.md)                               |
 | T23 | E2E 테스트 및 결제 팝업 모킹 전략                 | P2       | 진행 전 | 확인 필요    | T02, T03, T04, T01 | [T23_e2e_payment_popup_mocking_strategy.md](T23_e2e_payment_popup_mocking_strategy.md)                           |
-| T24 | CI 기본 파이프라인 구축                           | P1       | 진행 전 | 확인 필요    | 없음               | [T24_ci_lint_test_pipeline.md](T24_ci_lint_test_pipeline.md)                                                     |
+| T24 | CI 기본 파이프라인 구축                           | P1       | 완료    | 173          | 없음               | [T24_ci_lint_test_pipeline.md](T24_ci_lint_test_pipeline.md)                                                     |
 | T25 | hook input Domain/UI 타입 분리                    | P2       | 진행 전 | 확인 필요    | T15                | [T25_hook_input_domain_ui_type_split.md](T25_hook_input_domain_ui_type_split.md)                                 |
 | T26 | 운영 화면 summary/list API 분리                   | P2       | 진행 전 | 확인 필요    | T04                | [T26_admin_seller_summary_list_api_split.md](T26_admin_seller_summary_list_api_split.md)                         |
 | T27 | Auth 이메일/Supabase SMTP/rate limit 정책 정리    | P0       | 진행 전 | 확인 필요    | 없음               | [T27_auth_email_smtp_rate_limit_policy.md](T27_auth_email_smtp_rate_limit_policy.md)                             |

--- a/docs/tasks/T24_ci_lint_test_pipeline.md
+++ b/docs/tasks/T24_ci_lint_test_pipeline.md
@@ -1,10 +1,10 @@
 # T24. CI 기본 파이프라인 구축
 
 - 상태:
-  진행 전
+  완료
 
 - GitHub Issue:
-  확인 필요
+  173
 
 - 우선순위:
   P1
@@ -38,6 +38,14 @@
   - E2E는 T23 완료 후 별도 job으로 추가한다. 이 task에서는 포함하지 않는다.
   - Supabase env/mock mode secret 전략을 정리한다.
   - 로컬 Codex 환경에서는 `npm run build`를 실행하지 않지만, CI에서 build를 실행할지는 팀 결정이 필요하다.
+
+- 구현 메모:
+  - 기본 CI job은 `npm ci`, `npx playwright install --with-deps chromium`, `npm run lint`, `npm run typecheck`, `npm run test`를 실행한다.
+  - `npm run test`에는 Storybook/Vitest browser project가 포함되어 Chromium 설치가 필요하다.
+  - CI env는 외부 서비스에 연결하지 않는 mock/test placeholder 값을 사용한다.
+  - `npm run build`는 초기 CI 필수 job에서 제외하고, 팀 결정 후 별도 job으로 추가한다.
+  - E2E job은 T23 완료 후 추가한다.
+  - branch protection은 GitHub UI에서 `CI / Lint, typecheck, and test` 필수 check로 설정한다.
 
 - 관련 파일/영역:
   - `.github/workflows/ci.yml` (신규)


### PR DESCRIPTION
## 📌 작업 내용

- GitHub Actions 기본 CI workflow를 추가했습니다.
- PR과 `dev`/`main` push에서 lint, typecheck, test가 자동 실행되도록 구성했습니다.
- Vitest browser project 실행을 위해 CI에서 Playwright Chromium을 설치하도록 했습니다.

Task ID: T24

## 🔧 변경 사항

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서 수정

## 📚 문서/Task 반영

- [x] 관련 `docs/*` 최신화 필요 여부 확인
- [x] 필요한 문서 수정 반영 또는 후속 task/확인 필요로 기록
- [x] `docs/tasks` 상태와 GitHub Issue 번호 갱신

## 📂 주요 변경 파일

- `.github/workflows/ci.yml`
- `docs/system_architecture.md`
- `docs/tasks/T24_ci_lint_test_pipeline.md`
- `docs/tasks/README.md`

## 🧪 테스트 방법

- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npx prettier --check .github/workflows/ci.yml docs/system_architecture.md docs/tasks/T24_ci_lint_test_pipeline.md docs/tasks/README.md`

## 📸 스크린샷 (선택)

- UI 변경 없음

## 🔗 관련 이슈

- close #173 
