### PR TITLE
service role 사용 기준 및 owner scope 테스트 수립

### DIFF
--- a/docs/system_architecture.md
+++ b/docs/system_architecture.md
@@ -647,6 +647,8 @@ src/
 | `GET /api/admin/stores`                                      | P0       | admin                    | 없음        | 제외 (NOT_IMPLEMENTED) | T04                     |
 | `POST /api/seller-applications`                              | P0       | activeUser + eligibility | 없음        | 추가                   | —                       |
 | `GET /api/seller/onboarding-status`                          | P0       | activeUser               | 없음        | 추가                   | —                       |
+| `GET /api/users/me`                                          | P0       | activeUser               | 없음        | 미작성                 | —                       |
+| `POST /api/stores`                                           | P0       | seller                   | 있음        | 기존 확인              | —                       |
 | `GET /api/stores/me`                                         | P0       | seller                   | 있음        | 기존 확인              | —                       |
 | `GET /api/seller/products`                                   | P0       | seller                   | 있음        | 기존 확인              | —                       |
 | `POST /api/seller/products`                                  | P0       | seller                   | 있음        | 기존 확인              | —                       |
@@ -661,9 +663,14 @@ src/
 | `POST /api/orders`                                           | P0       | activeUser               | 있음        | 기존 확인              | —                       |
 | `GET /api/orders/[orderId]`                                  | P0       | owner                    | 있음        | 기존 확인              | —                       |
 | `POST /api/payments/prepare`                                 | P0       | activeUser               | 있음        | 기존 확인              | —                       |
+| `POST /api/payments/confirm`                                 | P0       | activeUser               | 있음        | 기존 확인              | —                       |
 | `POST /api/files/upload-url`                                 | P0       | purpose별                | 없음        | 추가                   | T16 (purpose 권한 강화) |
 | `GET /api/products/[productId]`                              | P0       | 없음 (public)            | 있음        | 기존 확인              | —                       |
 | `GET /api/stores`                                            | P1       | 없음 (public)            | 있음        | 기존 확인              | —                       |
+| `PATCH /api/users/me`                                        | P1       | activeUser               | 없음        | 미작성                 | —                       |
+| `DELETE /api/users/me`                                       | P1       | activeUser               | 없음        | 미작성                 | —                       |
+| `PATCH /api/stores/me`                                       | P1       | seller                   | 있음        | 기존 확인              | —                       |
 | `PATCH /api/orders/[orderId]/cancel`                         | P1       | owner                    | 없음        | 제외 (NOT_IMPLEMENTED) | T31                     |
+| `POST /api/payments/[paymentId]/cancel`                      | P1       | owner                    | 없음        | 제외 (NOT_IMPLEMENTED) | T31                     |
 | `PATCH /api/seller/orders/[orderId]/no-show`                 | P1       | sellerStore              | 없음        | 제외 (NOT_IMPLEMENTED) | T52                     |
 | `PATCH /api/seller/products/[productId]/stock`               | P1       | sellerStore              | 없음        | 제외 (NOT_IMPLEMENTED) | T09/T28                 |

--- a/docs/system_architecture.md
+++ b/docs/system_architecture.md
@@ -647,7 +647,7 @@ src/
 | `GET /api/admin/stores`                                      | P0       | admin                    | 없음        | 제외 (NOT_IMPLEMENTED) | T04                     |
 | `POST /api/seller-applications`                              | P0       | activeUser + eligibility | 없음        | 추가                   | —                       |
 | `GET /api/seller/onboarding-status`                          | P0       | activeUser               | 없음        | 추가                   | —                       |
-| `GET /api/users/me`                                          | P0       | activeUser               | 없음        | 미작성                 | —                       |
+| `GET /api/users/me`                                          | P0       | activeUser               | 없음        | 추가                   | —                       |
 | `POST /api/stores`                                           | P0       | seller                   | 있음        | 기존 확인              | —                       |
 | `GET /api/stores/me`                                         | P0       | seller                   | 있음        | 기존 확인              | —                       |
 | `GET /api/seller/products`                                   | P0       | seller                   | 있음        | 기존 확인              | —                       |
@@ -667,8 +667,8 @@ src/
 | `POST /api/files/upload-url`                                 | P0       | purpose별                | 없음        | 추가                   | T16 (purpose 권한 강화) |
 | `GET /api/products/[productId]`                              | P0       | 없음 (public)            | 있음        | 기존 확인              | —                       |
 | `GET /api/stores`                                            | P1       | 없음 (public)            | 있음        | 기존 확인              | —                       |
-| `PATCH /api/users/me`                                        | P1       | activeUser               | 없음        | 미작성                 | —                       |
-| `DELETE /api/users/me`                                       | P1       | activeUser               | 없음        | 미작성                 | —                       |
+| `PATCH /api/users/me`                                        | P1       | activeUser               | 없음        | 추가                   | —                       |
+| `DELETE /api/users/me`                                       | P1       | activeUser               | 없음        | 추가                   | —                       |
 | `PATCH /api/stores/me`                                       | P1       | seller                   | 있음        | 기존 확인              | —                       |
 | `PATCH /api/orders/[orderId]/cancel`                         | P1       | owner                    | 없음        | 제외 (NOT_IMPLEMENTED) | T31                     |
 | `POST /api/payments/[paymentId]/cancel`                      | P1       | owner                    | 없음        | 제외 (NOT_IMPLEMENTED) | T31                     |

--- a/docs/system_architecture.md
+++ b/docs/system_architecture.md
@@ -646,14 +646,24 @@ src/
 | `POST /api/admin/seller-application-documents/[id]/read-url` | P0       | admin                    | 없음        | 추가                   | —                       |
 | `GET /api/admin/stores`                                      | P0       | admin                    | 없음        | 제외 (NOT_IMPLEMENTED) | T04                     |
 | `POST /api/seller-applications`                              | P0       | activeUser + eligibility | 없음        | 추가                   | —                       |
-| `POST /api/files/upload-url`                                 | P1       | purpose별                | 없음        | 추가                   | T16 (purpose 권한 강화) |
-| `GET /api/seller/onboarding-status`                          | P1       | activeUser               | 없음        | 추가                   | —                       |
+| `GET /api/seller/onboarding-status`                          | P0       | activeUser               | 없음        | 추가                   | —                       |
+| `GET /api/stores/me`                                         | P0       | seller                   | 있음        | 기존 확인              | —                       |
+| `GET /api/seller/products`                                   | P0       | seller                   | 있음        | 기존 확인              | —                       |
+| `POST /api/seller/products`                                  | P0       | seller                   | 있음        | 기존 확인              | —                       |
+| `PATCH /api/seller/products/[productId]`                     | P0       | seller                   | 있음        | 기존 확인              | —                       |
+| `DELETE /api/seller/products/[productId]`                    | P0       | seller                   | 있음        | 기존 확인              | —                       |
 | `GET /api/seller/orders`                                     | P0       | sellerStore              | 있음        | 기존 확인              | —                       |
+| `GET /api/seller/orders/[orderId]`                           | P0       | sellerStore              | 있음        | 기존 확인              | —                       |
+| `PATCH /api/seller/orders/[orderId]/accept`                  | P0       | sellerStore              | 있음        | 기존 확인              | —                       |
+| `PATCH /api/seller/orders/[orderId]/ready`                   | P0       | sellerStore              | 있음        | 기존 확인              | —                       |
+| `PATCH /api/seller/orders/[orderId]/complete`                | P0       | sellerStore              | 있음        | 기존 확인              | —                       |
 | `GET /api/orders`                                            | P0       | activeUser               | 있음        | 기존 확인              | —                       |
 | `POST /api/orders`                                           | P0       | activeUser               | 있음        | 기존 확인              | —                       |
-| `GET /api/stores`                                            | P1       | 없음 (public)            | 있음        | 기존 확인              | —                       |
-| `GET /api/products/[productId]`                              | P1       | 없음 (public)            | 있음        | 기존 확인              | —                       |
+| `GET /api/orders/[orderId]`                                  | P0       | owner                    | 있음        | 기존 확인              | —                       |
 | `POST /api/payments/prepare`                                 | P0       | activeUser               | 있음        | 기존 확인              | —                       |
-| `POST /api/orders/[orderId]/cancel`                          | P0       | owner                    | 없음        | 제외 (NOT_IMPLEMENTED) | T31                     |
-| `POST /api/seller/orders/[orderId]/no-show`                  | P1       | sellerStore              | 없음        | 제외 (NOT_IMPLEMENTED) | T52                     |
+| `POST /api/files/upload-url`                                 | P0       | purpose별                | 없음        | 추가                   | T16 (purpose 권한 강화) |
+| `GET /api/products/[productId]`                              | P0       | 없음 (public)            | 있음        | 기존 확인              | —                       |
+| `GET /api/stores`                                            | P1       | 없음 (public)            | 있음        | 기존 확인              | —                       |
+| `PATCH /api/orders/[orderId]/cancel`                         | P1       | owner                    | 없음        | 제외 (NOT_IMPLEMENTED) | T31                     |
+| `PATCH /api/seller/orders/[orderId]/no-show`                 | P1       | sellerStore              | 없음        | 제외 (NOT_IMPLEMENTED) | T52                     |
 | `PATCH /api/seller/products/[productId]/stock`               | P1       | sellerStore              | 없음        | 제외 (NOT_IMPLEMENTED) | T09/T28                 |

--- a/docs/system_architecture.md
+++ b/docs/system_architecture.md
@@ -570,3 +570,90 @@ src/
 - Toss 지급대행/KYC 책임 범위 확정 시 서류 보관 의무 재검토. 세부 정책은 T44에서 결정한다.
 - 분쟁 대응에 필요한 최소 메타데이터 범위 확인 (운영/CS 정책).
 - public bucket(store-images, product-images, profile-images) orphan 처리는 P3에서 결정.
+
+---
+
+## 14. service role 사용 기준
+
+`createServiceRoleClient()`는 RLS를 우회하므로 남용하면 사용자·판매자·관리자 데이터 노출 위험이 생긴다. 반드시 아래 허용 케이스에 해당할 때만 사용한다.
+
+### 14.1 허용 케이스
+
+| 케이스                | 설명                                                          | 예시                                                           |
+| --------------------- | ------------------------------------------------------------- | -------------------------------------------------------------- |
+| RPC 호출              | DB function은 RLS가 아닌 SECURITY DEFINER로 실행              | `create_order`, `confirm_payment`, `create_seller_application` |
+| 초기 row 생성         | 사용자 최초 로그인 시 users row INSERT — RLS INSERT 정책 없음 | `getOrCreateUserByAuthUser`                                    |
+| admin cross-user 조작 | admin이 타 사용자 데이터 조회/변경                            | `getPendingSellerApplications`, `approveSellerApplication`     |
+| Storage API           | Supabase Storage에는 RLS가 없어 service role 필수             | `createSignedUploadUrl`, Storage orphan cleanup                |
+
+### 14.2 금지 케이스
+
+단순 owner-scoped SELECT는 service role을 사용하지 않는다. `createServerClient()` + RLS 정책으로 처리한다.
+
+- `orders.user_id = auth.uid()` 기준 소비자 주문 조회
+- `products.store_id ∈ 내 가게` 기준 판매자 상품 조회
+- `users.id = auth.uid()` 기준 프로필 조회/수정
+
+### 14.3 RLS 전환 후보 목록
+
+현재 service role을 사용하지만 RLS+server client로 전환 가능한 후보다. 전환 전 해당 테이블의 RLS 정책 추가가 전제 조건이며, 실제 전환은 후속 task에서 수행한다.
+
+| 파일                                       | 함수                                                               | scope 유형                                 | 전제 조건          |
+| ------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------ | ------------------ |
+| `_lib/auth.ts`                             | `checkApplicationEligibility`                                      | `seller_applications.user_id = auth.uid()` | RLS 정책 확인 필요 |
+| `orders/_lib/service.ts`                   | `getOrders`, `getOrder`                                            | `orders.user_id = auth.uid()`              | RLS 정책 추가      |
+| `seller/orders/_lib/service.ts`            | `getSellerOrders`, `getSellerOrder`                                | `orders.store_id ∈ 내 가게`                | RLS 정책 추가      |
+| `seller/orders/_lib/service.ts`            | `acceptSellerOrder`, `markSellerOrderReady`, `completeSellerOrder` | store 소유권 필터                          | RLS 정책 추가      |
+| `seller/products/_lib/service.ts`          | 전체                                                               | `products.store_id ∈ 내 가게`              | RLS 정책 추가      |
+| `seller/menu-items/_lib/service.ts`        | 전체                                                               | `menu_items.store_id ∈ 내 가게`            | RLS 정책 추가      |
+| `seller/onboarding-status/_lib/service.ts` | `getSellerOnboardingStatus`                                        | 여러 테이블 user 소유                      | RLS 정책 추가      |
+| `users/me/_lib/service.ts`                 | profile 조회/수정                                                  | `users.id = auth.uid()`                    | RLS 정책 확인      |
+
+---
+
+## 15. Route Handler 보안 checklist
+
+신규 Route Handler를 구현하거나 기존 Route Handler를 수정할 때 아래 항목을 확인한다.
+
+### 15.1 auth helper 선택 기준
+
+| 조건                           | 사용할 helper                                           |
+| ------------------------------ | ------------------------------------------------------- |
+| 로그인 사용자 전용 (role 무관) | `requireActiveUser()`                                   |
+| 판매자 전용 (가게 불필요)      | `requireSeller()`                                       |
+| 판매자 전용 + 가게 필요        | `requireSellerStore()`                                  |
+| 관리자 전용                    | `requireAdmin()`                                        |
+| 판매자 신청 자격 확인          | `requireActiveUser()` + `checkApplicationEligibility()` |
+
+### 15.2 owner scope 검증 원칙
+
+- auth helper가 반환한 `authUser.id` / `store.id`를 service에 직접 전달해 소유권 필터를 적용한다.
+- service 내부에서 params의 id를 무검증으로 사용하지 않는다. Route Handler에서 auth → params → service 순서로 검증한다.
+- 민감 리소스(admin 전용, 개인 문서, 결제)는 auth를 params/body 검증보다 먼저 수행하는 것을 권장한다.
+
+### 15.3 응답 민감도 원칙
+
+- 에러 응답에 DB 쿼리 오류 메시지, 내부 파일 경로, 타 사용자 ID 등 민감 정보를 포함하지 않는다.
+- `routeError(error)`는 `AppError`만 클라이언트에 노출하고, 그 외는 `INTERNAL_SERVER_ERROR`로 처리한다.
+
+### 15.4 P0/P1 API owner scope 테스트 커버리지
+
+| API                                                          | 우선순위 | 필요 scope               | 현재 테스트 | T07 조치               | 후속 task               |
+| ------------------------------------------------------------ | -------- | ------------------------ | ----------- | ---------------------- | ----------------------- |
+| `GET /api/admin/sellers/pending`                             | P0       | admin                    | 없음        | 추가                   | —                       |
+| `POST /api/admin/sellers/[id]/approve`                       | P0       | admin                    | 없음        | 추가                   | —                       |
+| `POST /api/admin/sellers/[id]/reject`                        | P0       | admin                    | 없음        | 추가                   | —                       |
+| `POST /api/admin/seller-application-documents/[id]/read-url` | P0       | admin                    | 없음        | 추가                   | —                       |
+| `GET /api/admin/stores`                                      | P0       | admin                    | 없음        | 제외 (NOT_IMPLEMENTED) | T04                     |
+| `POST /api/seller-applications`                              | P0       | activeUser + eligibility | 없음        | 추가                   | —                       |
+| `POST /api/files/upload-url`                                 | P1       | purpose별                | 없음        | 추가                   | T16 (purpose 권한 강화) |
+| `GET /api/seller/onboarding-status`                          | P1       | activeUser               | 없음        | 추가                   | —                       |
+| `GET /api/seller/orders`                                     | P0       | sellerStore              | 있음        | 기존 확인              | —                       |
+| `GET /api/orders`                                            | P0       | activeUser               | 있음        | 기존 확인              | —                       |
+| `POST /api/orders`                                           | P0       | activeUser               | 있음        | 기존 확인              | —                       |
+| `GET /api/stores`                                            | P1       | 없음 (public)            | 있음        | 기존 확인              | —                       |
+| `GET /api/products/[productId]`                              | P1       | 없음 (public)            | 있음        | 기존 확인              | —                       |
+| `POST /api/payments/prepare`                                 | P0       | activeUser               | 있음        | 기존 확인              | —                       |
+| `POST /api/orders/[orderId]/cancel`                          | P0       | owner                    | 없음        | 제외 (NOT_IMPLEMENTED) | T31                     |
+| `POST /api/seller/orders/[orderId]/no-show`                  | P1       | sellerStore              | 없음        | 제외 (NOT_IMPLEMENTED) | T52                     |
+| `PATCH /api/seller/products/[productId]/stock`               | P1       | sellerStore              | 없음        | 제외 (NOT_IMPLEMENTED) | T09/T28                 |

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -31,7 +31,7 @@ PickMa 심화 프로젝트 task의 공유 기준 문서다. `temp/`는 로컬 �
 | T04 | 관리자 가게 목록 real endpoint 및 화면 구현       | P0       | 진행 전 | 확인 필요    | T07                | [T04_admin_stores_real_endpoint_page.md](T04_admin_stores_real_endpoint_page.md)                                 |
 | T05 | 상품 목록 할인율 필터/정렬 DB pagination 복구     | P0       | 진행 전 | 확인 필요    | T08                | [T05_product_discount_sort_db_pagination.md](T05_product_discount_sort_db_pagination.md)                         |
 | T06 | Storage orphan 및 개인정보 cleanup 정책 확정      | P0       | 완료    | 확인 필요    | 없음               | [T06_storage_orphan_privacy_cleanup_policy.md](T06_storage_orphan_privacy_cleanup_policy.md)                     |
-| T07 | service role 사용 기준 및 owner scope 테스트 수립 | P0       | 진행 중 | 175          | 없음               | [T07_service_role_owner_scope_tests.md](T07_service_role_owner_scope_tests.md)                                   |
+| T07 | service role 사용 기준 및 owner scope 테스트 수립 | P0       | 완료    | 175          | 없음               | [T07_service_role_owner_scope_tests.md](T07_service_role_owner_scope_tests.md)                                   |
 | T08 | incremental migration 전환 결정                   | P0       | 진행 전 | 확인 필요    | 없음               | [T08_incremental_migration_policy.md](T08_incremental_migration_policy.md)                                       |
 | T09 | 501 API 및 UI 노출 목록 정리                      | P0       | 진행 전 | 확인 필요    | 없음               | [T09_api_501_ui_exposure_inventory.md](T09_api_501_ui_exposure_inventory.md)                                     |
 | T10 | 판매자 운영 상태 정책 및 구현                     | P1       | 진행 전 | 확인 필요    | T08                | [T10_seller_operation_status.md](T10_seller_operation_status.md)                                                 |

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -31,7 +31,7 @@ PickMa 심화 프로젝트 task의 공유 기준 문서다. `temp/`는 로컬 �
 | T04 | 관리자 가게 목록 real endpoint 및 화면 구현       | P0       | 진행 전 | 확인 필요    | T07                | [T04_admin_stores_real_endpoint_page.md](T04_admin_stores_real_endpoint_page.md)                                 |
 | T05 | 상품 목록 할인율 필터/정렬 DB pagination 복구     | P0       | 진행 전 | 확인 필요    | T08                | [T05_product_discount_sort_db_pagination.md](T05_product_discount_sort_db_pagination.md)                         |
 | T06 | Storage orphan 및 개인정보 cleanup 정책 확정      | P0       | 완료    | 확인 필요    | 없음               | [T06_storage_orphan_privacy_cleanup_policy.md](T06_storage_orphan_privacy_cleanup_policy.md)                     |
-| T07 | service role 사용 기준 및 owner scope 테스트 수립 | P0       | 진행 전 | 확인 필요    | 없음               | [T07_service_role_owner_scope_tests.md](T07_service_role_owner_scope_tests.md)                                   |
+| T07 | service role 사용 기준 및 owner scope 테스트 수립 | P0       | 진행 중 | 175          | 없음               | [T07_service_role_owner_scope_tests.md](T07_service_role_owner_scope_tests.md)                                   |
 | T08 | incremental migration 전환 결정                   | P0       | 진행 전 | 확인 필요    | 없음               | [T08_incremental_migration_policy.md](T08_incremental_migration_policy.md)                                       |
 | T09 | 501 API 및 UI 노출 목록 정리                      | P0       | 진행 전 | 확인 필요    | 없음               | [T09_api_501_ui_exposure_inventory.md](T09_api_501_ui_exposure_inventory.md)                                     |
 | T10 | 판매자 운영 상태 정책 및 구현                     | P1       | 진행 전 | 확인 필요    | T08                | [T10_seller_operation_status.md](T10_seller_operation_status.md)                                                 |

--- a/docs/tasks/T07_service_role_owner_scope_tests.md
+++ b/docs/tasks/T07_service_role_owner_scope_tests.md
@@ -1,10 +1,10 @@
 # T07. service role 사용 기준 및 owner scope 테스트 수립
 
 - 상태:
-  진행 전
+  진행 중
 
 - GitHub Issue:
-  확인 필요
+  175
 
 - 우선순위:
   P0

--- a/docs/tasks/T07_service_role_owner_scope_tests.md
+++ b/docs/tasks/T07_service_role_owner_scope_tests.md
@@ -55,5 +55,5 @@
   - `docs/system_architecture.md` §15 Route Handler 보안 checklist (auth helper 선택 기준, owner scope 원칙, P0/P1 API 커버리지 표) 신설
   - admin seller route 4개 `route.test.ts` 신규 작성 (pending, approve, reject, read-url)
   - seller-applications, files/upload-url, seller/onboarding-status `route.test.ts` 신규 작성
-  - 전체 API 테스트 469개 통과, lint 에러 없음
+  - 전체 API 테스트 482개 통과, lint 에러 없음
   - NOT_IMPLEMENTED route (admin/stores, orders/cancel, seller/no-show, seller/stock) 테스트는 후속 task(T04, T31, T52, T09/T28)로 명시적 이관

--- a/docs/tasks/T07_service_role_owner_scope_tests.md
+++ b/docs/tasks/T07_service_role_owner_scope_tests.md
@@ -1,7 +1,7 @@
 # T07. service role 사용 기준 및 owner scope 테스트 수립
 
 - 상태:
-  진행 중
+  완료
 
 - GitHub Issue:
   175
@@ -49,3 +49,11 @@
   - service role 사용 기준 문서가 있다.
   - P0/P1 API의 owner scope 테스트 목록이 확정된다.
   - 신규 API 구현 시 참고할 checklist가 생긴다.
+
+- 구현 결과:
+  - `docs/system_architecture.md` §14 service role 사용 기준 (허용 4가지, 금지, RLS 전환 후보표) 신설
+  - `docs/system_architecture.md` §15 Route Handler 보안 checklist (auth helper 선택 기준, owner scope 원칙, P0/P1 API 커버리지 표) 신설
+  - admin seller route 4개 `route.test.ts` 신규 작성 (pending, approve, reject, read-url)
+  - seller-applications, files/upload-url, seller/onboarding-status `route.test.ts` 신규 작성
+  - 전체 API 테스트 469개 통과, lint 에러 없음
+  - NOT_IMPLEMENTED route (admin/stores, orders/cancel, seller/no-show, seller/stock) 테스트는 후속 task(T04, T31, T52, T09/T28)로 명시적 이관

--- a/src/app/api/admin/seller-application-documents/[id]/read-url/route.test.ts
+++ b/src/app/api/admin/seller-application-documents/[id]/read-url/route.test.ts
@@ -77,6 +77,18 @@ describe('POST /api/admin/seller-application-documents/[id]/read-url', () => {
     expect(body.data.signedUrl).toBe(mockDocumentReadUrl.signedUrl);
   });
 
+  it('잘못된 UUID params는 400을 반환하고 service를 호출하지 않는다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireAdmin).mockResolvedValue(adminResult);
+
+    const res = await POST(makeRequest(), makeParams('not-a-uuid'));
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+    expect(getSellerApplicationDocumentReadUrl).not.toHaveBeenCalled();
+  });
+
   it('requireAdmin이 실패하면 error envelope를 반환한다', async () => {
     vi.mocked(isApiMockEnabled).mockReturnValue(false);
     vi.mocked(requireAdmin).mockRejectedValue(

--- a/src/app/api/admin/seller-application-documents/[id]/read-url/route.test.ts
+++ b/src/app/api/admin/seller-application-documents/[id]/read-url/route.test.ts
@@ -1,0 +1,92 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SellerApplicationDocumentReadUrlResponse } from '@/contracts/seller-application';
+import { AppError } from '@/lib/errors/appError';
+import { ERROR_CODE } from '@/lib/errors/errorCodes';
+import { requireAdmin } from '@/app/api/_lib/auth';
+import { isApiMockEnabled } from '@/app/api/_lib/mock';
+import { mockDocumentReadUrl } from '@/mocks/admin';
+
+import { POST } from './route';
+import { getSellerApplicationDocumentReadUrl } from '../../_lib/service';
+
+vi.mock('@/app/api/_lib/auth', () => ({
+  requireAdmin: vi.fn(),
+}));
+
+vi.mock('@/app/api/_lib/mock', () => ({
+  isApiMockEnabled: vi.fn(),
+}));
+
+vi.mock('../../_lib/service', () => ({
+  getSellerApplicationDocumentReadUrl: vi.fn(),
+}));
+
+const DOCUMENT_ID = '00000000-0000-4000-8000-000000000001';
+
+const adminResult = {
+  authUser: {},
+  serviceUser: {},
+} as Awaited<ReturnType<typeof requireAdmin>>;
+
+function makeRequest(): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/admin/seller-application-documents/${DOCUMENT_ID}/read-url`,
+    { method: 'POST' }
+  );
+}
+
+function makeParams(id = DOCUMENT_ID) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe('POST /api/admin/seller-application-documents/[id]/read-url', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('mock 모드에서 mockDocumentReadUrl을 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(true);
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = (await res.json()) as {
+      data: SellerApplicationDocumentReadUrlResponse;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.data.signedUrl).toBe(mockDocumentReadUrl.signedUrl);
+    expect(requireAdmin).not.toHaveBeenCalled();
+  });
+
+  it('real 모드에서 requireAdmin 호출 후 getSellerApplicationDocumentReadUrl을 호출한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireAdmin).mockResolvedValue(adminResult);
+    vi.mocked(getSellerApplicationDocumentReadUrl).mockResolvedValue(
+      mockDocumentReadUrl
+    );
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = (await res.json()) as {
+      data: SellerApplicationDocumentReadUrlResponse;
+    };
+
+    expect(res.status).toBe(200);
+    expect(requireAdmin).toHaveBeenCalledOnce();
+    expect(getSellerApplicationDocumentReadUrl).toHaveBeenCalledWith(
+      DOCUMENT_ID
+    );
+    expect(body.data.signedUrl).toBe(mockDocumentReadUrl.signedUrl);
+  });
+
+  it('requireAdmin이 실패하면 error envelope를 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireAdmin).mockRejectedValue(
+      new AppError(ERROR_CODE.FORBIDDEN, 403)
+    );
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(403);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+});

--- a/src/app/api/admin/seller-application-documents/[id]/read-url/route.ts
+++ b/src/app/api/admin/seller-application-documents/[id]/read-url/route.ts
@@ -1,5 +1,7 @@
 import type { NextRequest } from 'next/server';
 
+import { AppError } from '@/lib/errors/appError';
+import { ERROR_CODE } from '@/lib/errors/errorCodes';
 import { requireAdmin } from '@/app/api/_lib/auth';
 import { isApiMockEnabled } from '@/app/api/_lib/mock';
 import { routeError, success } from '@/app/api/_lib/response';
@@ -16,7 +18,9 @@ export async function POST(
 
   try {
     await requireAdmin();
-    const { id } = paramsIdSchema.parse(await params);
+    const result = paramsIdSchema.safeParse(await params);
+    if (!result.success) throw new AppError(ERROR_CODE.VALIDATION_ERROR, 400);
+    const { id } = result.data;
     const data = await getSellerApplicationDocumentReadUrl(id);
     return success(data);
   } catch (error) {

--- a/src/app/api/admin/seller-application-documents/[id]/read-url/route.ts
+++ b/src/app/api/admin/seller-application-documents/[id]/read-url/route.ts
@@ -19,7 +19,16 @@ export async function POST(
   try {
     await requireAdmin();
     const result = paramsIdSchema.safeParse(await params);
-    if (!result.success) throw new AppError(ERROR_CODE.VALIDATION_ERROR, 400);
+    if (!result.success)
+      throw new AppError(
+        ERROR_CODE.VALIDATION_ERROR,
+        400,
+        undefined,
+        result.error.issues.map((issue) => ({
+          path: issue.path.join('.'),
+          message: issue.message,
+        }))
+      );
     const { id } = result.data;
     const data = await getSellerApplicationDocumentReadUrl(id);
     return success(data);

--- a/src/app/api/admin/sellers/[id]/approve/route.test.ts
+++ b/src/app/api/admin/sellers/[id]/approve/route.test.ts
@@ -65,6 +65,18 @@ describe('POST /api/admin/sellers/[id]/approve', () => {
     expect(approveSellerApplication).toHaveBeenCalledWith(SELLER_ID);
   });
 
+  it('잘못된 UUID params는 400을 반환하고 service를 호출하지 않는다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireAdmin).mockResolvedValue(adminResult);
+
+    const res = await POST(makeRequest(), makeParams('not-a-uuid'));
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+    expect(approveSellerApplication).not.toHaveBeenCalled();
+  });
+
   it('requireAdmin이 실패하면 error envelope를 반환한다', async () => {
     vi.mocked(isApiMockEnabled).mockReturnValue(false);
     vi.mocked(requireAdmin).mockRejectedValue(

--- a/src/app/api/admin/sellers/[id]/approve/route.test.ts
+++ b/src/app/api/admin/sellers/[id]/approve/route.test.ts
@@ -1,0 +1,80 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AppError } from '@/lib/errors/appError';
+import { ERROR_CODE } from '@/lib/errors/errorCodes';
+import { requireAdmin } from '@/app/api/_lib/auth';
+import { isApiMockEnabled } from '@/app/api/_lib/mock';
+
+import { POST } from './route';
+import { approveSellerApplication } from '../../_lib/service';
+
+vi.mock('@/app/api/_lib/auth', () => ({
+  requireAdmin: vi.fn(),
+}));
+
+vi.mock('@/app/api/_lib/mock', () => ({
+  isApiMockEnabled: vi.fn(),
+}));
+
+vi.mock('../../_lib/service', () => ({
+  approveSellerApplication: vi.fn(),
+}));
+
+const SELLER_ID = '00000000-0000-4000-8000-000000000001';
+
+const adminResult = {
+  authUser: {},
+  serviceUser: {},
+} as Awaited<ReturnType<typeof requireAdmin>>;
+
+function makeRequest(): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/admin/sellers/${SELLER_ID}/approve`,
+    { method: 'POST' }
+  );
+}
+
+function makeParams(id = SELLER_ID) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe('POST /api/admin/sellers/[id]/approve', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('mock 모드에서 null을 반환하고 requireAdmin을 호출하지 않는다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(true);
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = (await res.json()) as { data: null };
+
+    expect(res.status).toBe(200);
+    expect(body.data).toBeNull();
+    expect(requireAdmin).not.toHaveBeenCalled();
+  });
+
+  it('real 모드에서 requireAdmin 호출 후 approveSellerApplication을 호출한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireAdmin).mockResolvedValue(adminResult);
+    vi.mocked(approveSellerApplication).mockResolvedValue(undefined);
+
+    const res = await POST(makeRequest(), makeParams());
+
+    expect(res.status).toBe(200);
+    expect(requireAdmin).toHaveBeenCalledOnce();
+    expect(approveSellerApplication).toHaveBeenCalledWith(SELLER_ID);
+  });
+
+  it('requireAdmin이 실패하면 error envelope를 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireAdmin).mockRejectedValue(
+      new AppError(ERROR_CODE.FORBIDDEN, 403)
+    );
+
+    const res = await POST(makeRequest(), makeParams());
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(403);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+});

--- a/src/app/api/admin/sellers/[id]/approve/route.ts
+++ b/src/app/api/admin/sellers/[id]/approve/route.ts
@@ -18,7 +18,16 @@ export async function POST(
   try {
     await requireAdmin();
     const result = paramsIdSchema.safeParse(await params);
-    if (!result.success) throw new AppError(ERROR_CODE.VALIDATION_ERROR, 400);
+    if (!result.success)
+      throw new AppError(
+        ERROR_CODE.VALIDATION_ERROR,
+        400,
+        undefined,
+        result.error.issues.map((issue) => ({
+          path: issue.path.join('.'),
+          message: issue.message,
+        }))
+      );
     const { id } = result.data;
     await approveSellerApplication(id);
     return success(null);

--- a/src/app/api/admin/sellers/[id]/approve/route.ts
+++ b/src/app/api/admin/sellers/[id]/approve/route.ts
@@ -1,5 +1,7 @@
 import type { NextRequest } from 'next/server';
 
+import { AppError } from '@/lib/errors/appError';
+import { ERROR_CODE } from '@/lib/errors/errorCodes';
 import { requireAdmin } from '@/app/api/_lib/auth';
 import { isApiMockEnabled } from '@/app/api/_lib/mock';
 import { routeError, success } from '@/app/api/_lib/response';
@@ -11,12 +13,13 @@ export async function POST(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<Response> {
-  const { id } = paramsIdSchema.parse(await params);
-
   if (isApiMockEnabled()) return success(null);
 
   try {
     await requireAdmin();
+    const result = paramsIdSchema.safeParse(await params);
+    if (!result.success) throw new AppError(ERROR_CODE.VALIDATION_ERROR, 400);
+    const { id } = result.data;
     await approveSellerApplication(id);
     return success(null);
   } catch (error) {

--- a/src/app/api/admin/sellers/[id]/reject/route.test.ts
+++ b/src/app/api/admin/sellers/[id]/reject/route.test.ts
@@ -1,0 +1,108 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AppError } from '@/lib/errors/appError';
+import { ERROR_CODE } from '@/lib/errors/errorCodes';
+import { requireAdmin } from '@/app/api/_lib/auth';
+import { isApiMockEnabled } from '@/app/api/_lib/mock';
+
+import { POST } from './route';
+import { rejectSellerApplication } from '../../_lib/service';
+
+vi.mock('@/app/api/_lib/auth', () => ({
+  requireAdmin: vi.fn(),
+}));
+
+vi.mock('@/app/api/_lib/mock', () => ({
+  isApiMockEnabled: vi.fn(),
+}));
+
+vi.mock('../../_lib/service', () => ({
+  rejectSellerApplication: vi.fn(),
+}));
+
+const SELLER_ID = '00000000-0000-4000-8000-000000000001';
+const REJECT_REASON = '서류 미제출';
+
+const adminResult = {
+  authUser: {},
+  serviceUser: {},
+} as Awaited<ReturnType<typeof requireAdmin>>;
+
+function makePostRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/admin/sellers/${SELLER_ID}/reject`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function makeParams(id = SELLER_ID) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe('POST /api/admin/sellers/[id]/reject', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('mock 모드에서 null을 반환하고 requireAdmin을 호출하지 않는다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(true);
+
+    const res = await POST(
+      makePostRequest({ reason: REJECT_REASON }),
+      makeParams()
+    );
+    const body = (await res.json()) as { data: null };
+
+    expect(res.status).toBe(200);
+    expect(body.data).toBeNull();
+    expect(requireAdmin).not.toHaveBeenCalled();
+  });
+
+  it('real 모드에서 reason 없는 body는 400을 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireAdmin).mockResolvedValue(adminResult);
+
+    const res = await POST(makePostRequest({}), makeParams());
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('real 모드에서 requireAdmin 호출 후 rejectSellerApplication을 호출한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireAdmin).mockResolvedValue(adminResult);
+    vi.mocked(rejectSellerApplication).mockResolvedValue(undefined);
+
+    const res = await POST(
+      makePostRequest({ reason: REJECT_REASON }),
+      makeParams()
+    );
+
+    expect(res.status).toBe(200);
+    expect(requireAdmin).toHaveBeenCalledOnce();
+    expect(rejectSellerApplication).toHaveBeenCalledWith(
+      SELLER_ID,
+      REJECT_REASON
+    );
+  });
+
+  it('requireAdmin이 실패하면 error envelope를 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireAdmin).mockRejectedValue(
+      new AppError(ERROR_CODE.FORBIDDEN, 403)
+    );
+
+    const res = await POST(
+      makePostRequest({ reason: REJECT_REASON }),
+      makeParams()
+    );
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(403);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+});

--- a/src/app/api/admin/sellers/[id]/reject/route.test.ts
+++ b/src/app/api/admin/sellers/[id]/reject/route.test.ts
@@ -90,6 +90,21 @@ describe('POST /api/admin/sellers/[id]/reject', () => {
     );
   });
 
+  it('잘못된 UUID params는 400을 반환하고 service를 호출하지 않는다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireAdmin).mockResolvedValue(adminResult);
+
+    const res = await POST(
+      makePostRequest({ reason: REJECT_REASON }),
+      makeParams('not-a-uuid')
+    );
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+    expect(rejectSellerApplication).not.toHaveBeenCalled();
+  });
+
   it('requireAdmin이 실패하면 error envelope를 반환한다', async () => {
     vi.mocked(isApiMockEnabled).mockReturnValue(false);
     vi.mocked(requireAdmin).mockRejectedValue(

--- a/src/app/api/admin/sellers/[id]/reject/route.ts
+++ b/src/app/api/admin/sellers/[id]/reject/route.ts
@@ -1,5 +1,7 @@
 import type { NextRequest } from 'next/server';
 
+import { AppError } from '@/lib/errors/appError';
+import { ERROR_CODE } from '@/lib/errors/errorCodes';
 import { requireAdmin } from '@/app/api/_lib/auth';
 import { isApiMockEnabled } from '@/app/api/_lib/mock';
 import { routeError, success } from '@/app/api/_lib/response';
@@ -15,12 +17,13 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<Response> {
-  const { id } = paramsIdSchema.parse(await params);
-
   if (isApiMockEnabled()) return success(null);
 
   try {
     await requireAdmin();
+    const result = paramsIdSchema.safeParse(await params);
+    if (!result.success) throw new AppError(ERROR_CODE.VALIDATION_ERROR, 400);
+    const { id } = result.data;
     const body = await validateBody(rejectSellerApplicationSchema, request);
     await rejectSellerApplication(id, body.reason);
     return success(null);

--- a/src/app/api/admin/sellers/[id]/reject/route.ts
+++ b/src/app/api/admin/sellers/[id]/reject/route.ts
@@ -22,7 +22,16 @@ export async function POST(
   try {
     await requireAdmin();
     const result = paramsIdSchema.safeParse(await params);
-    if (!result.success) throw new AppError(ERROR_CODE.VALIDATION_ERROR, 400);
+    if (!result.success)
+      throw new AppError(
+        ERROR_CODE.VALIDATION_ERROR,
+        400,
+        undefined,
+        result.error.issues.map((issue) => ({
+          path: issue.path.join('.'),
+          message: issue.message,
+        }))
+      );
     const { id } = result.data;
     const body = await validateBody(rejectSellerApplicationSchema, request);
     await rejectSellerApplication(id, body.reason);

--- a/src/app/api/admin/sellers/pending/route.test.ts
+++ b/src/app/api/admin/sellers/pending/route.test.ts
@@ -42,10 +42,12 @@ describe('GET /api/admin/sellers/pending', () => {
 
     const res = await GET(makeGetRequest());
     const body = (await res.json()) as {
+      statusCode: number;
       data: AdminPendingSellerApplicationListResponse;
     };
 
     expect(res.status).toBe(200);
+    expect(body.statusCode).toBe(res.status);
     expect(body.data.items).toHaveLength(
       mockAdminPendingSellerApplicationList.items.length
     );
@@ -71,9 +73,13 @@ describe('GET /api/admin/sellers/pending', () => {
     vi.mocked(requireAdmin).mockResolvedValue(adminResult);
 
     const res = await GET(makeGetRequest('page=-1'));
-    const body = (await res.json()) as { error: { code: string } };
+    const body = (await res.json()) as {
+      statusCode: number;
+      error: { code: string };
+    };
 
     expect(res.status).toBe(400);
+    expect(body.statusCode).toBe(res.status);
     expect(body.error.code).toBe('VALIDATION_ERROR');
   });
 
@@ -84,9 +90,13 @@ describe('GET /api/admin/sellers/pending', () => {
     );
 
     const res = await GET(makeGetRequest());
-    const body = (await res.json()) as { error: { code: string } };
+    const body = (await res.json()) as {
+      statusCode: number;
+      error: { code: string };
+    };
 
     expect(res.status).toBe(403);
+    expect(body.statusCode).toBe(res.status);
     expect(body.error.code).toBe('FORBIDDEN');
   });
 });

--- a/src/app/api/admin/sellers/pending/route.test.ts
+++ b/src/app/api/admin/sellers/pending/route.test.ts
@@ -1,0 +1,92 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AdminPendingSellerApplicationListResponse } from '@/contracts/admin';
+import { AppError } from '@/lib/errors/appError';
+import { ERROR_CODE } from '@/lib/errors/errorCodes';
+import { requireAdmin } from '@/app/api/_lib/auth';
+import { isApiMockEnabled } from '@/app/api/_lib/mock';
+import { mockAdminPendingSellerApplicationList } from '@/mocks/admin';
+
+import { GET } from './route';
+import { getPendingSellerApplications } from '../_lib/service';
+
+vi.mock('@/app/api/_lib/auth', () => ({
+  requireAdmin: vi.fn(),
+}));
+
+vi.mock('@/app/api/_lib/mock', () => ({
+  isApiMockEnabled: vi.fn(),
+}));
+
+vi.mock('../_lib/service', () => ({
+  getPendingSellerApplications: vi.fn(),
+}));
+
+const adminResult = {
+  authUser: {},
+  serviceUser: {},
+} as Awaited<ReturnType<typeof requireAdmin>>;
+
+function makeGetRequest(search = ''): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/admin/sellers/pending${search ? `?${search}` : ''}`
+  );
+}
+
+describe('GET /api/admin/sellers/pending', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('mock 모드에서 mockAdminPendingSellerApplicationList를 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(true);
+
+    const res = await GET(makeGetRequest());
+    const body = (await res.json()) as {
+      data: AdminPendingSellerApplicationListResponse;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.data.items).toHaveLength(
+      mockAdminPendingSellerApplicationList.items.length
+    );
+    expect(requireAdmin).not.toHaveBeenCalled();
+  });
+
+  it('real 모드에서 requireAdmin 호출 후 page/pageSize로 service를 호출한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireAdmin).mockResolvedValue(adminResult);
+    vi.mocked(getPendingSellerApplications).mockResolvedValue(
+      mockAdminPendingSellerApplicationList
+    );
+
+    const res = await GET(makeGetRequest());
+
+    expect(res.status).toBe(200);
+    expect(requireAdmin).toHaveBeenCalledOnce();
+    expect(getPendingSellerApplications).toHaveBeenCalledWith(1, 20);
+  });
+
+  it('real 모드에서 잘못된 query는 400을 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireAdmin).mockResolvedValue(adminResult);
+
+    const res = await GET(makeGetRequest('page=-1'));
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('requireAdmin이 실패하면 error envelope를 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireAdmin).mockRejectedValue(
+      new AppError(ERROR_CODE.FORBIDDEN, 403)
+    );
+
+    const res = await GET(makeGetRequest());
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(403);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+});

--- a/src/app/api/files/upload-url/route.test.ts
+++ b/src/app/api/files/upload-url/route.test.ts
@@ -81,6 +81,7 @@ describe('POST /api/files/upload-url', () => {
 
     expect(res.status).toBe(201);
     expect(resBody.data.signedUrl).toBe('/api/mock/upload');
+    expect(resBody.data.storagePath).toBe('mock/profile_image/mock-file');
     expect(requireActiveUser).not.toHaveBeenCalled();
   });
 

--- a/src/app/api/files/upload-url/route.test.ts
+++ b/src/app/api/files/upload-url/route.test.ts
@@ -1,0 +1,229 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AppError } from '@/lib/errors/appError';
+import { ERROR_CODE } from '@/lib/errors/errorCodes';
+import {
+  checkApplicationEligibility,
+  requireActiveUser,
+  requireSeller,
+  requireSellerStore,
+} from '@/app/api/_lib/auth';
+import { isApiMockEnabled } from '@/app/api/_lib/mock';
+
+import { createFileUploadUrl } from './_lib/service';
+import { POST } from './route';
+
+vi.mock('@/app/api/_lib/auth', () => ({
+  requireActiveUser: vi.fn(),
+  requireSeller: vi.fn(),
+  requireSellerStore: vi.fn(),
+  checkApplicationEligibility: vi.fn(),
+}));
+
+vi.mock('@/app/api/_lib/mock', () => ({
+  isApiMockEnabled: vi.fn(),
+}));
+
+vi.mock('./_lib/service', () => ({
+  createFileUploadUrl: vi.fn(),
+}));
+
+const USER_ID = '00000000-0000-4000-8000-000000000001';
+const STORE_ID = '00000000-0000-4000-8000-000000000031';
+
+const activeUserResult = {
+  authUser: { id: USER_ID },
+  serviceUser: { role: 'consumer', status: 'active' },
+} as unknown as Awaited<ReturnType<typeof requireActiveUser>>;
+
+const sellerResult = {
+  authUser: { id: USER_ID },
+  serviceUser: { role: 'seller', status: 'active' },
+} as unknown as Awaited<ReturnType<typeof requireSeller>>;
+
+const sellerStoreResult = {
+  authUser: { id: USER_ID },
+  serviceUser: { role: 'seller', status: 'active' },
+  store: { id: STORE_ID },
+} as unknown as Awaited<ReturnType<typeof requireSellerStore>>;
+
+const mockUploadUrlResponse = {
+  signedUrl: 'https://example.com/signed-url',
+  storagePath: 'mock/profile_image/mock-file',
+};
+
+function makePostRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/files/upload-url', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/files/upload-url', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('mock 모드에서 signedUrl과 storagePath를 201로 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(true);
+
+    const body = {
+      purpose: 'profile_image',
+      fileName: 'photo.jpg',
+      fileSize: 1024,
+      mimeType: 'image/jpeg',
+    };
+
+    const res = await POST(makePostRequest(body));
+    const resBody = (await res.json()) as {
+      data: { signedUrl: string; storagePath: string };
+    };
+
+    expect(res.status).toBe(201);
+    expect(resBody.data.signedUrl).toBe('/api/mock/upload');
+    expect(requireActiveUser).not.toHaveBeenCalled();
+  });
+
+  it('body 누락 시 400을 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(true);
+
+    const res = await POST(makePostRequest({}));
+    const resBody = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(400);
+    expect(resBody.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('purpose=profile_image이면 requireActiveUser를 호출한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireActiveUser).mockResolvedValue(activeUserResult);
+    vi.mocked(createFileUploadUrl).mockResolvedValue(mockUploadUrlResponse);
+
+    const res = await POST(
+      makePostRequest({
+        purpose: 'profile_image',
+        fileName: 'photo.jpg',
+        fileSize: 1024,
+        mimeType: 'image/jpeg',
+      })
+    );
+
+    expect(res.status).toBe(201);
+    expect(requireActiveUser).toHaveBeenCalledOnce();
+    expect(createFileUploadUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ purpose: 'profile_image' }),
+      USER_ID,
+      undefined
+    );
+  });
+
+  it('purpose=seller_application_document이면 requireActiveUser + checkApplicationEligibility를 호출한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireActiveUser).mockResolvedValue(activeUserResult);
+    vi.mocked(checkApplicationEligibility).mockResolvedValue({
+      eligible: true,
+    });
+    vi.mocked(createFileUploadUrl).mockResolvedValue(mockUploadUrlResponse);
+
+    const res = await POST(
+      makePostRequest({
+        purpose: 'seller_application_document',
+        fileName: 'doc.pdf',
+        fileSize: 2048,
+        mimeType: 'application/pdf',
+        documentType: 'business_license',
+      })
+    );
+
+    expect(res.status).toBe(201);
+    expect(requireActiveUser).toHaveBeenCalledOnce();
+    expect(checkApplicationEligibility).toHaveBeenCalledWith(
+      USER_ID,
+      activeUserResult.serviceUser.role
+    );
+  });
+
+  it('purpose=seller_application_document에서 eligibility 실패 시 409를 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireActiveUser).mockResolvedValue(activeUserResult);
+    vi.mocked(checkApplicationEligibility).mockResolvedValue({
+      eligible: false,
+      reason: 'application_already_submitted',
+    });
+
+    const res = await POST(
+      makePostRequest({
+        purpose: 'seller_application_document',
+        fileName: 'doc.pdf',
+        fileSize: 2048,
+        mimeType: 'application/pdf',
+        documentType: 'business_license',
+      })
+    );
+    const resBody = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(409);
+    expect(resBody.error.code).toBe('APPLICATION_ALREADY_SUBMITTED');
+  });
+
+  it('purpose=store_image이면 requireSeller를 호출한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireSeller).mockResolvedValue(sellerResult);
+    vi.mocked(createFileUploadUrl).mockResolvedValue(mockUploadUrlResponse);
+
+    const res = await POST(
+      makePostRequest({
+        purpose: 'store_image',
+        fileName: 'store.jpg',
+        fileSize: 1024,
+        mimeType: 'image/jpeg',
+      })
+    );
+
+    expect(res.status).toBe(201);
+    expect(requireSeller).toHaveBeenCalledOnce();
+  });
+
+  it('purpose=seller_product_image이면 requireSellerStore를 호출하고 storeId를 service에 전달한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireSellerStore).mockResolvedValue(sellerStoreResult);
+    vi.mocked(createFileUploadUrl).mockResolvedValue(mockUploadUrlResponse);
+
+    const res = await POST(
+      makePostRequest({
+        purpose: 'seller_product_image',
+        fileName: 'product.jpg',
+        fileSize: 1024,
+        mimeType: 'image/jpeg',
+      })
+    );
+
+    expect(res.status).toBe(201);
+    expect(requireSellerStore).toHaveBeenCalledOnce();
+    expect(createFileUploadUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ purpose: 'seller_product_image' }),
+      USER_ID,
+      STORE_ID
+    );
+  });
+
+  it('requireActiveUser가 실패하면 error envelope를 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireActiveUser).mockRejectedValue(
+      new AppError(ERROR_CODE.UNAUTHORIZED, 401)
+    );
+
+    const res = await POST(
+      makePostRequest({
+        purpose: 'profile_image',
+        fileName: 'photo.jpg',
+        fileSize: 1024,
+        mimeType: 'image/jpeg',
+      })
+    );
+    const resBody = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(401);
+    expect(resBody.error.code).toBe('UNAUTHORIZED');
+  });
+});

--- a/src/app/api/seller-applications/route.test.ts
+++ b/src/app/api/seller-applications/route.test.ts
@@ -1,0 +1,174 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SellerApplicationResponse } from '@/contracts/seller-application';
+import { AppError } from '@/lib/errors/appError';
+import { ERROR_CODE } from '@/lib/errors/errorCodes';
+import {
+  checkApplicationEligibility,
+  requireActiveUser,
+} from '@/app/api/_lib/auth';
+import { isApiMockEnabled } from '@/app/api/_lib/mock';
+import { mockSellerApplication } from '@/mocks/seller';
+
+import { createSellerApplication } from './_lib/service';
+import { POST } from './route';
+
+vi.mock('@/app/api/_lib/auth', () => ({
+  requireActiveUser: vi.fn(),
+  checkApplicationEligibility: vi.fn(),
+}));
+
+vi.mock('@/app/api/_lib/mock', () => ({
+  isApiMockEnabled: vi.fn(),
+}));
+
+vi.mock('./_lib/service', () => ({
+  createSellerApplication: vi.fn(),
+}));
+
+const USER_ID = '00000000-0000-4000-8000-000000000001';
+
+const activeUserResult = {
+  authUser: { id: USER_ID },
+  serviceUser: { role: 'consumer', status: 'active' },
+} as unknown as Awaited<ReturnType<typeof requireActiveUser>>;
+
+const VALID_BODY = {
+  businessNumber: '123-45-67890',
+  companyName: '테스트 회사',
+  representativeName: '홍길동',
+  businessAddress: '서울시 강남구 테스트로 1',
+  businessType: '음식업',
+  businessCategory: '한식',
+  documents: [
+    {
+      type: 'business_license',
+      storagePath: 'user-id/upload-id/business_license/file.pdf',
+      originalFileName: 'business_license.pdf',
+      contentType: 'application/pdf',
+      size: 1024,
+    },
+    {
+      type: 'id_card',
+      storagePath: 'user-id/upload-id/id_card/file.pdf',
+      originalFileName: 'id_card.pdf',
+      contentType: 'application/pdf',
+      size: 1024,
+    },
+    {
+      type: 'bankbook',
+      storagePath: 'user-id/upload-id/bankbook/file.pdf',
+      originalFileName: 'bankbook.pdf',
+      contentType: 'application/pdf',
+      size: 1024,
+    },
+    {
+      type: 'business_report',
+      storagePath: 'user-id/upload-id/business_report/file.pdf',
+      originalFileName: 'business_report.pdf',
+      contentType: 'application/pdf',
+      size: 1024,
+    },
+  ],
+};
+
+function makePostRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/seller-applications', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/seller-applications', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('mock 모드에서 mockSellerApplication을 201로 반환하고 auth를 호출하지 않는다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(true);
+
+    const res = await POST(makePostRequest(VALID_BODY));
+    const body = (await res.json()) as { data: SellerApplicationResponse };
+
+    expect(res.status).toBe(201);
+    expect(body.data.id).toBe(mockSellerApplication.id);
+    expect(requireActiveUser).not.toHaveBeenCalled();
+  });
+
+  it('잘못된 body는 400을 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(true);
+
+    const res = await POST(makePostRequest({}));
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('real 모드에서 requireActiveUser → checkApplicationEligibility → createSellerApplication 순서로 호출한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireActiveUser).mockResolvedValue(activeUserResult);
+    vi.mocked(checkApplicationEligibility).mockResolvedValue({
+      eligible: true,
+    });
+    vi.mocked(createSellerApplication).mockResolvedValue(mockSellerApplication);
+
+    const res = await POST(makePostRequest(VALID_BODY));
+
+    expect(res.status).toBe(201);
+    expect(requireActiveUser).toHaveBeenCalledOnce();
+    expect(checkApplicationEligibility).toHaveBeenCalledWith(
+      USER_ID,
+      activeUserResult.serviceUser.role
+    );
+    expect(createSellerApplication).toHaveBeenCalledWith(
+      USER_ID,
+      expect.objectContaining({ businessNumber: VALID_BODY.businessNumber })
+    );
+  });
+
+  it('requireActiveUser가 실패하면 error envelope를 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireActiveUser).mockRejectedValue(
+      new AppError(ERROR_CODE.UNAUTHORIZED, 401)
+    );
+
+    const res = await POST(makePostRequest(VALID_BODY));
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(401);
+    expect(body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('eligibility가 seller_already_registered이면 409를 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireActiveUser).mockResolvedValue(activeUserResult);
+    vi.mocked(checkApplicationEligibility).mockResolvedValue({
+      eligible: false,
+      reason: 'seller_already_registered',
+    });
+
+    const res = await POST(makePostRequest(VALID_BODY));
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(409);
+    expect(body.error.code).toBe('SELLER_ALREADY_REGISTERED');
+    expect(createSellerApplication).not.toHaveBeenCalled();
+  });
+
+  it('eligibility가 application_already_submitted이면 409를 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireActiveUser).mockResolvedValue(activeUserResult);
+    vi.mocked(checkApplicationEligibility).mockResolvedValue({
+      eligible: false,
+      reason: 'application_already_submitted',
+    });
+
+    const res = await POST(makePostRequest(VALID_BODY));
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(409);
+    expect(body.error.code).toBe('APPLICATION_ALREADY_SUBMITTED');
+    expect(createSellerApplication).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/seller/onboarding-status/route.test.ts
+++ b/src/app/api/seller/onboarding-status/route.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SellerOnboardingStatusResponse } from '@/contracts/seller-application';
+import { AppError } from '@/lib/errors/appError';
+import { ERROR_CODE } from '@/lib/errors/errorCodes';
+import { requireActiveUser } from '@/app/api/_lib/auth';
+import { isApiMockEnabled } from '@/app/api/_lib/mock';
+import { mockSellerOnboardingStatus } from '@/mocks/seller';
+
+import { toSellerOnboardingStatusResponse } from './_lib/mapper';
+import { getSellerOnboardingStatus } from './_lib/service';
+import { GET } from './route';
+
+vi.mock('@/app/api/_lib/auth', () => ({
+  requireActiveUser: vi.fn(),
+}));
+
+vi.mock('@/app/api/_lib/mock', () => ({
+  isApiMockEnabled: vi.fn(),
+}));
+
+vi.mock('./_lib/service', () => ({
+  getSellerOnboardingStatus: vi.fn(),
+}));
+
+vi.mock('./_lib/mapper', () => ({
+  toSellerOnboardingStatusResponse: vi.fn((data) => data),
+}));
+
+const USER_ID = '00000000-0000-4000-8000-000000000001';
+
+const activeUserResult = {
+  authUser: { id: USER_ID },
+  serviceUser: {},
+} as unknown as Awaited<ReturnType<typeof requireActiveUser>>;
+
+describe('GET /api/seller/onboarding-status', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('mock 모드에서 mockSellerOnboardingStatus를 반환하고 auth를 호출하지 않는다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(true);
+
+    const res = await GET();
+    const body = (await res.json()) as {
+      data: SellerOnboardingStatusResponse;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.data).toEqual(mockSellerOnboardingStatus);
+    expect(requireActiveUser).not.toHaveBeenCalled();
+  });
+
+  it('real 모드에서 requireActiveUser 호출 후 authUser.id로 service를 호출한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireActiveUser).mockResolvedValue(activeUserResult);
+    vi.mocked(getSellerOnboardingStatus).mockResolvedValue(
+      mockSellerOnboardingStatus
+    );
+    vi.mocked(toSellerOnboardingStatusResponse).mockReturnValue(
+      mockSellerOnboardingStatus
+    );
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    expect(requireActiveUser).toHaveBeenCalledOnce();
+    expect(getSellerOnboardingStatus).toHaveBeenCalledWith(USER_ID);
+    expect(toSellerOnboardingStatusResponse).toHaveBeenCalledOnce();
+  });
+
+  it('requireActiveUser가 실패하면 error envelope를 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireActiveUser).mockRejectedValue(
+      new AppError(ERROR_CODE.FORBIDDEN, 403)
+    );
+
+    const res = await GET();
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(403);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+});

--- a/src/app/api/users/me/route.test.ts
+++ b/src/app/api/users/me/route.test.ts
@@ -1,0 +1,180 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { UserResponse } from '@/contracts/user';
+import { AppError } from '@/lib/errors/appError';
+import { ERROR_CODE } from '@/lib/errors/errorCodes';
+import { requireActiveUser } from '@/app/api/_lib/auth';
+import { isApiMockEnabled } from '@/app/api/_lib/mock';
+import { mockUser } from '@/mocks/users';
+
+import { updateUser } from './_lib/service';
+import { DELETE, GET, PATCH } from './route';
+
+vi.mock('@/app/api/_lib/auth', () => ({
+  requireActiveUser: vi.fn(),
+}));
+
+vi.mock('@/app/api/_lib/mock', () => ({
+  isApiMockEnabled: vi.fn(),
+}));
+
+vi.mock('./_lib/service', () => ({
+  updateUser: vi.fn(),
+}));
+
+const USER_ID = '00000000-0000-4000-8000-000000000001';
+
+const activeUserResult = {
+  authUser: { id: USER_ID },
+  serviceUser: { id: USER_ID, role: 'customer', status: 'active' },
+} as unknown as Awaited<ReturnType<typeof requireActiveUser>>;
+
+function makeGetRequest(): NextRequest {
+  return new NextRequest('http://localhost/api/users/me');
+}
+
+function makePatchRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/users/me', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('GET /api/users/me', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('mock 모드에서 mockUser를 반환하고 requireActiveUser를 호출하지 않는다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(true);
+
+    const res = await GET(makeGetRequest());
+    const body = (await res.json()) as { data: UserResponse };
+
+    expect(res.status).toBe(200);
+    expect(body.data.email).toBe(mockUser.email);
+    expect(requireActiveUser).not.toHaveBeenCalled();
+  });
+
+  it('real 모드에서 requireActiveUser 호출 후 serviceUser를 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireActiveUser).mockResolvedValue(activeUserResult);
+
+    const res = await GET(makeGetRequest());
+    const body = (await res.json()) as { data: { id: string } };
+
+    expect(res.status).toBe(200);
+    expect(requireActiveUser).toHaveBeenCalledOnce();
+    expect(body.data.id).toBe(USER_ID);
+  });
+
+  it('requireActiveUser가 실패하면 error envelope를 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireActiveUser).mockRejectedValue(
+      new AppError(ERROR_CODE.UNAUTHORIZED, 401)
+    );
+
+    const res = await GET(makeGetRequest());
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(401);
+    expect(body.error.code).toBe('UNAUTHORIZED');
+  });
+});
+
+describe('PATCH /api/users/me', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('mock 모드에서 수정된 사용자 정보를 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(true);
+
+    const res = await PATCH(makePatchRequest({ name: '새 이름' }));
+    const body = (await res.json()) as { data: UserResponse };
+
+    expect(res.status).toBe(200);
+    expect(body.data.name).toBe('새 이름');
+    expect(requireActiveUser).not.toHaveBeenCalled();
+  });
+
+  it('mock 모드에서 빈 body는 400을 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(true);
+
+    const res = await PATCH(makePatchRequest({}));
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('real 모드에서 requireActiveUser 호출 후 serviceUser.id로 updateUser를 호출한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireActiveUser).mockResolvedValue(activeUserResult);
+    vi.mocked(updateUser).mockResolvedValue({
+      ...mockUser,
+      id: USER_ID,
+      name: '새 이름',
+    });
+
+    const res = await PATCH(makePatchRequest({ name: '새 이름' }));
+
+    expect(res.status).toBe(200);
+    expect(requireActiveUser).toHaveBeenCalledOnce();
+    expect(updateUser).toHaveBeenCalledWith(
+      USER_ID,
+      expect.objectContaining({ name: '새 이름' })
+    );
+  });
+
+  it('requireActiveUser가 실패하면 error envelope를 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireActiveUser).mockRejectedValue(
+      new AppError(ERROR_CODE.FORBIDDEN, 403)
+    );
+
+    const res = await PATCH(makePatchRequest({ name: '새 이름' }));
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(403);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+});
+
+describe('DELETE /api/users/me', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('mock 모드에서 null을 반환하고 requireActiveUser를 호출하지 않는다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(true);
+
+    const res = await DELETE();
+    const body = (await res.json()) as { data: null };
+
+    expect(res.status).toBe(200);
+    expect(body.data).toBeNull();
+    expect(requireActiveUser).not.toHaveBeenCalled();
+  });
+
+  it('real 모드에서 requireActiveUser 호출 후 501을 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireActiveUser).mockResolvedValue(activeUserResult);
+
+    const res = await DELETE();
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(501);
+    expect(body.error.code).toBe('NOT_IMPLEMENTED');
+    expect(requireActiveUser).toHaveBeenCalledOnce();
+  });
+
+  it('requireActiveUser가 실패하면 error envelope를 반환한다', async () => {
+    vi.mocked(isApiMockEnabled).mockReturnValue(false);
+    vi.mocked(requireActiveUser).mockRejectedValue(
+      new AppError(ERROR_CODE.UNAUTHORIZED, 401)
+    );
+
+    const res = await DELETE();
+    const body = (await res.json()) as { error: { code: string } };
+
+    expect(res.status).toBe(401);
+    expect(body.error.code).toBe('UNAUTHORIZED');
+  });
+});


### PR DESCRIPTION
## 📌 작업 내용

service role 사용 기준을 문서화하고, P0/P1 API에 owner/admin scope 테스트를 추가해 보안 베이스라인을 확립한다.

Task ID: T07

## 🔧 변경 사항

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 문서 수정

## 📚 문서/Task 반영

- [x] 관련 `docs/*` 최신화 필요 여부 확인
- [x] 필요한 문서 수정 반영 또는 후속 task/확인 필요로 기록
- [x] `docs/tasks` 상태와 GitHub Issue 번호 갱신

## 📂 주요 변경 파일

- `docs/system_architecture.md` — §14 service role 사용 기준, §15 Route Handler 보안 checklist 신설
- `src/app/api/admin/sellers/pending/route.test.ts` (신규)
- `src/app/api/admin/sellers/[id]/approve/route.ts` — params 검증 safeParse+AppError 교체
- `src/app/api/admin/sellers/[id]/approve/route.test.ts` (신규)
- `src/app/api/admin/sellers/[id]/reject/route.ts` — params 검증 safeParse+AppError 교체
- `src/app/api/admin/sellers/[id]/reject/route.test.ts` (신규)
- `src/app/api/admin/seller-application-documents/[id]/read-url/route.ts` — params 검증 safeParse+AppError 교체
- `src/app/api/admin/seller-application-documents/[id]/read-url/route.test.ts` (신규)
- `src/app/api/seller-applications/route.test.ts` (신규)
- `src/app/api/files/upload-url/route.test.ts` (신규)
- `src/app/api/seller/onboarding-status/route.test.ts` (신규)
- `src/app/api/users/me/route.test.ts` (신규)

## 🧪 테스트 방법

- `npx vitest run src/app/api` — 482개 전체 통과

## 📸 스크린샷 (선택)

해당 없음

## 🔗 관련 이슈

- close #175
