### PR TITLE
결제 outbox/webhook/idempotency 설계

### DIFF
--- a/docs/api_spec.md
+++ b/docs/api_spec.md
@@ -815,10 +815,15 @@ Toss가 호출하는 결제 상태 동기화 endpoint이다. 구현 우선순위
 
 **검증 방식**
 
-| eventType                | 검증 방법                                                                  |
-| ------------------------ | -------------------------------------------------------------------------- |
-| `PAYMENT_STATUS_CHANGED` | HMAC 서명 없음. payload의 `orderNumber`, `amount`를 DB와 교차 검증 + HTTPS |
-| `DEPOSIT_CALLBACK`       | payload의 `secret` 필드를 `payments.pg_response.secret`에 저장된 값과 비교 |
+Toss webhook body 구조 (이벤트별 상이):
+
+- `PAYMENT_STATUS_CHANGED`: `{ eventType, createdAt, data: { paymentKey, orderId, totalAmount, status, ... } }` — 결제 정보는 `data` 안에 위치
+- `DEPOSIT_CALLBACK`: `{ createdAt, secret, status, orderId, transactionKey }` — 필드가 루트에 위치
+
+| eventType                | 검증 방법                                                                                           |
+| ------------------------ | --------------------------------------------------------------------------------------------------- |
+| `PAYMENT_STATUS_CHANGED` | HMAC 서명 없음. `body.data.orderId`(=orderNumber), `body.data.totalAmount`를 DB와 교차 검증 + HTTPS |
+| `DEPOSIT_CALLBACK`       | `body.secret`을 `payments.pg_response.secret`과 비교. `body.orderId`(=orderNumber)로 대상 결제 조회 |
 
 `TOSS_WEBHOOK_SECRET` 환경변수는 사용하지 않는다.
 

--- a/docs/api_spec.md
+++ b/docs/api_spec.md
@@ -802,9 +802,42 @@ DB source:
 
 ### 6.5 `POST /api/payments/webhook`
 
-- Toss가 호출하는 결제 상태 동기화 endpoint이다.
-- Toss MVP adapter 구현 시 운영 필수성을 재판정한다. 명세 기본 우선순위는 P1이다.
-- 서명/secret 검증과 멱등 처리가 필요하다.
+Toss가 호출하는 결제 상태 동기화 endpoint이다. 구현 우선순위: P1. 구현: T63. 설계 문서: `docs/payment_event_design.md`.
+
+**허용 이벤트 타입**
+
+| Toss eventType           | 처리 내용             |
+| ------------------------ | --------------------- |
+| `PAYMENT_STATUS_CHANGED` | 결제 상태 변화 동기화 |
+| `DEPOSIT_CALLBACK`       | 가상계좌 입금 확인    |
+
+허용 결제수단: `card`, `virtual_account`, `mobile`, `easy_pay`
+
+**검증 방식**
+
+| eventType                | 검증 방법                                                                  |
+| ------------------------ | -------------------------------------------------------------------------- |
+| `PAYMENT_STATUS_CHANGED` | HMAC 서명 없음. payload의 `orderNumber`, `amount`를 DB와 교차 검증 + HTTPS |
+| `DEPOSIT_CALLBACK`       | payload의 `secret` 필드를 `payments.pg_response.secret`에 저장된 값과 비교 |
+
+`TOSS_WEBHOOK_SECRET` 환경변수는 사용하지 않는다.
+
+**Idempotency**
+
+- `tosspayments-webhook-transmission-id` 헤더를 `payment_events.provider_event_id`에 저장한다.
+- `(provider, provider_event_id)` unique index로 retry/중복 수신을 차단한다.
+- 중복 수신 시 `200 OK` 반환 (멱등 처리).
+
+**`DEPOSIT_CALLBACK` 검증을 위한 secret 저장**
+
+Toss confirm 응답에서 최소 필드만 `payments.pg_response` jsonb에 저장한다: `paymentKey`, `orderId`, `method`, `status`, `secret`. 카드번호, 계좌번호, 고객 식별성이 높은 상세 정보는 저장하지 않는다.
+
+**처리 흐름**
+
+1. `provider_event_id` 중복 확인 → 중복이면 `200 OK`
+2. `payment_webhook_received` 이벤트 INSERT (`status='pending'`)
+3. 이벤트 타입별 처리
+4. `status='processed'`, `processed_at=now()` 갱신
 
 ---
 

--- a/docs/payment_event_design.md
+++ b/docs/payment_event_design.md
@@ -25,6 +25,7 @@ CREATE TABLE payment_events (
   id                  uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
   order_id            uuid        NOT NULL REFERENCES orders(id),
   order_number        text        NOT NULL,
+  store_id            uuid        REFERENCES stores(id),    -- 판매자 Realtime 필터용
   payment_id          uuid        REFERENCES payments(id),  -- 결제 완료 전에는 NULL
   event_type          text        NOT NULL,
   provider            text,                                 -- 'toss' 등 결제 provider
@@ -43,6 +44,8 @@ CREATE UNIQUE INDEX payment_events_provider_event_uniq
   ON payment_events (provider, provider_event_id)
   WHERE provider_event_id IS NOT NULL;
 ```
+
+`store_id`는 Supabase Realtime 판매자 채널 필터(`store_id=eq.{storeId}`)에 사용한다. `payment_compensation_failed`, `payment_stuck_processing`처럼 store 맥락이 없는 이벤트는 NULL이다.
 
 `payment_id`는 `payment_confirmed` 이후 채워진다. `payment_compensation_failed`는 `confirm_payment` RPC 실패 후에 발생하므로 payment row가 없을 수 있다.
 
@@ -189,7 +192,13 @@ Supabase Realtime으로 `payment_events` 테이블 INSERT를 구독한다.
 | 판매자      | `payment_confirmed`                                       | 신규 주문 알림 |
 | 관리자      | `payment_compensation_failed`, `payment_stuck_processing` | 운영 알람      |
 
-채널 필터는 `order_id` 또는 `store_id`(payload에 포함) 기준으로 격리한다. 구현 상세는 T22에서 결정한다.
+채널 필터:
+
+- 소비자: `order_id=eq.{orderId}` (자기 주문만 구독)
+- 판매자: `store_id=eq.{storeId}` (DB column 기준 Realtime 필터)
+- 관리자: 이벤트 타입 필터 (`event_type=in.(payment_compensation_failed,payment_stuck_processing)`)
+
+`store_id`는 `payment_events` column으로 저장된다. 구현 상세는 T22에서 결정한다.
 
 ---
 

--- a/docs/payment_event_design.md
+++ b/docs/payment_event_design.md
@@ -111,10 +111,40 @@ DB에는 `payments(provider, provider_payment_key)` partial unique index가 이�
 
 Toss webhook은 이벤트별로 다른 검증 방식을 사용한다.
 
-| eventType                | 검증 방법                                                                                       |
-| ------------------------ | ----------------------------------------------------------------------------------------------- |
-| `PAYMENT_STATUS_CHANGED` | HMAC 서명 없음. payload의 `orderNumber`, `amount`를 DB `orders`, `payments`와 교차 검증 + HTTPS |
-| `DEPOSIT_CALLBACK`       | payload의 `secret` 필드를 `payments.pg_response.secret`에 저장된 값과 비교                      |
+Toss webhook body는 이벤트별로 구조가 다르다.
+
+`PAYMENT_STATUS_CHANGED`:
+
+```jsonc
+{
+  "eventType": "PAYMENT_STATUS_CHANGED",
+  "createdAt": "<ISO string>",
+  "data": {
+    "paymentKey": "<string>", // provider_key
+    "orderId": "<string>", // PickMa orderNumber
+    "totalAmount": 15000, // 검증 대상 금액
+    "status": "<string>",
+    // ...Payment 객체 나머지 필드
+  },
+}
+```
+
+`DEPOSIT_CALLBACK`:
+
+```jsonc
+{
+  "createdAt": "<ISO string>",
+  "secret": "<string>", // payments.pg_response.secret과 비교
+  "status": "DONE",
+  "orderId": "<string>", // PickMa orderNumber
+  "transactionKey": "<string>",
+}
+```
+
+| eventType                | 검증 방법                                                                                                                |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `PAYMENT_STATUS_CHANGED` | HMAC 서명 없음. `body.data.orderId`(=orderNumber), `body.data.totalAmount`를 DB `orders`, `payments`와 교차 검증 + HTTPS |
+| `DEPOSIT_CALLBACK`       | `body.secret`을 `payments.pg_response.secret`에 저장된 값과 비교. `body.orderId`(=orderNumber)로 대상 결제 조회          |
 
 `TOSS_WEBHOOK_SECRET` 환경변수는 사용하지 않는다. Toss는 `PAYMENT_STATUS_CHANGED`에 HMAC 서명을 제공하지 않는다.
 

--- a/docs/payment_event_design.md
+++ b/docs/payment_event_design.md
@@ -78,6 +78,16 @@ CREATE UNIQUE INDEX payment_events_provider_event_uniq
 - `failureStage='toss_cancel'`: Toss 승인 결제가 남아 있을 수 있다. 운영자는 Toss 결제 상태를 확인하고 취소/환불 또는 주문 복구를 결정한다.
 - `failureStage='revert_processing'`: Toss cancel은 성공했을 수 있으나 주문이 `processing`에 잔류한다. 운영자는 주문 상태 복구를 우선 확인한다.
 
+### 이벤트 타입별 INSERT 기본 `status`
+
+| event_type                    | INSERT 시 status | 비고                                              |
+| ----------------------------- | ---------------- | ------------------------------------------------- |
+| `payment_confirmed`           | `processed`      | INSERT 즉시 완결                                  |
+| `payment_compensation_failed` | `processed`      | INSERT 즉시 완결, 수동 대응 필요 기록용           |
+| `payment_stuck_processing`    | `processed`      | INSERT 즉시 완결                                  |
+| `payment_webhook_received`    | `pending`        | 처리 완료 후 `processed`, 실패 시 `failed`로 갱신 |
+| `payment_cancelled`           | `processed`      | INSERT 즉시 완결                                  |
+
 ---
 
 ## 4. Confirm Idempotency

--- a/docs/payment_event_design.md
+++ b/docs/payment_event_design.md
@@ -1,0 +1,184 @@
+# 결제 이벤트 모델 설계
+
+결제 흐름에서 발생하는 이벤트를 추적하기 위한 `payment_events` 테이블 스키마, 이벤트 타입, webhook 수신 정책, idempotency 기준을 정의한다.
+
+T11 설계 문서. 구현은 T62(migration + event contract), T63(webhook Route Handler)에서 진행한다.
+
+---
+
+## 1. 설계 배경
+
+T01에서 Option B 보상 정책을 채택했다. Toss confirm 성공 후 `confirm_payment` RPC가 실패하면 Toss 자동 취소를 시도하고, 취소 또는 revert가 실패하면 주문은 `processing`에 잔류한다. 이 gap 상태를 포함한 모든 결제 이벤트를 추적 가능한 형태로 기록하기 위해 `payment_events` 이벤트 로그 테이블을 도입한다.
+
+**이벤트 로그 방식 채택 이유:**
+
+- Outbox pattern은 전용 상시 worker가 필요하다. Vercel 환경에서는 상시 worker 운용이 어렵다.
+- Event log는 append-only 기록이며, 처리 주체를 Cron(T43), webhook 수신, API 진입 등 다양하게 선택할 수 있다.
+- Supabase Realtime으로 `payment_events` 테이블 INSERT를 구독하면 T22 notification 연동이 자연스럽다.
+
+---
+
+## 2. `payment_events` 테이블 스키마
+
+```sql
+CREATE TABLE payment_events (
+  id                  uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id            uuid        NOT NULL REFERENCES orders(id),
+  order_number        text        NOT NULL,
+  payment_id          uuid        REFERENCES payments(id),  -- 결제 완료 전에는 NULL
+  event_type          text        NOT NULL,
+  provider            text,                                 -- 'toss' 등 결제 provider
+  provider_key        text,                                 -- provider_payment_key 등 결제 식별자
+  provider_event_type text,                                 -- Toss webhook eventType 등
+  provider_event_id   text,                                 -- tosspayments-webhook-transmission-id 등
+  payload             jsonb,
+  status              text        NOT NULL DEFAULT 'pending', -- 'pending' | 'processed' | 'failed'
+  error_message       text,
+  processed_at        timestamptz,
+  created_at          timestamptz NOT NULL DEFAULT now()
+);
+
+-- webhook 중복 수신 방지
+CREATE UNIQUE INDEX payment_events_provider_event_uniq
+  ON payment_events (provider, provider_event_id)
+  WHERE provider_event_id IS NOT NULL;
+```
+
+`payment_id`는 `payment_confirmed` 이후 채워진다. `payment_compensation_failed`는 `confirm_payment` RPC 실패 후에 발생하므로 payment row가 없을 수 있다.
+
+---
+
+## 3. 이벤트 타입
+
+| event_type                    | 발생 시점                                                   | 삽입 위치                            | 소비 주체                  |
+| ----------------------------- | ----------------------------------------------------------- | ------------------------------------ | -------------------------- |
+| `payment_confirmed`           | `confirm_payment` RPC 성공 직후                             | RPC 내부 (atomic)                    | T22 realtime notification  |
+| `payment_compensation_failed` | `callTossCancel` 실패 또는 `revert_payment_processing` 실패 | `service.ts` 보상 블록 (best-effort) | 운영 알람                  |
+| `payment_stuck_processing`    | `processing` 30분 이상 잔류 감지                            | Cron job (T43 scope)                 | 운영 알람                  |
+| `payment_webhook_received`    | Toss webhook 수신 직후                                      | webhook Route Handler (T63)          | 상태 동기화                |
+| `payment_cancelled`           | 결제 취소 완료 직후                                         | 취소 RPC 내부 (T31)                  | T22 notification, T31 정산 |
+
+### `payment_compensation_failed` payload
+
+```jsonc
+{
+  "failureStage": "toss_cancel" | "revert_processing",
+  "paymentStateAssumption": "approved_may_remain" | "cancelled_may_be_done",
+  "manualAction": "check_toss_and_cancel_or_refund" | "restore_order_status",
+  "orderStatus": "processing",
+  "tossPaymentKey": "<string | null>"
+}
+```
+
+운영 판단 기준:
+
+- `failureStage='toss_cancel'`: Toss 승인 결제가 남아 있을 수 있다. 운영자는 Toss 결제 상태를 확인하고 취소/환불 또는 주문 복구를 결정한다.
+- `failureStage='revert_processing'`: Toss cancel은 성공했을 수 있으나 주문이 `processing`에 잔류한다. 운영자는 주문 상태 복구를 우선 확인한다.
+
+---
+
+## 4. Confirm Idempotency
+
+DB에는 `payments(provider, provider_payment_key)` partial unique index가 이미 존재한다. 별도 constraint 추가 없이 다음 두 계층에서 idempotency를 보장한다.
+
+| 계층      | 방식                                                             | 비고                                                                           |
+| --------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Toss API  | `Idempotency-Key: confirm:{orderNumber}:{paymentKey}` 헤더       | 동일 key 재요청 시 Toss가 동일 결과 반환                                       |
+| PickMa DB | 주문 상태 검증 (`payment_pending`만 허용) + RPC unique violation | 중복 confirm 시도는 `INVALID_ORDER_STATUS` 또는 unique constraint error로 차단 |
+
+후속 구현(T62)에서 중복 confirm 응답을 `PAYMENT_ALREADY_CONFIRMED` 에러로 명확히 매핑할지 결정한다.
+
+---
+
+## 5. Toss Webhook 정책
+
+### 5.1 엔드포인트
+
+`POST /api/payments/webhook` (구현: T63)
+
+### 5.2 허용 이벤트 타입
+
+| Toss eventType           | 처리 내용             |
+| ------------------------ | --------------------- |
+| `PAYMENT_STATUS_CHANGED` | 결제 상태 변화 동기화 |
+| `DEPOSIT_CALLBACK`       | 가상계좌 입금 확인    |
+
+### 5.3 허용 결제수단
+
+`card`, `virtual_account`, `mobile`, `easy_pay`
+
+### 5.4 검증 방식
+
+Toss webhook은 이벤트별로 다른 검증 방식을 사용한다.
+
+| eventType                | 검증 방법                                                                                       |
+| ------------------------ | ----------------------------------------------------------------------------------------------- |
+| `PAYMENT_STATUS_CHANGED` | HMAC 서명 없음. payload의 `orderNumber`, `amount`를 DB `orders`, `payments`와 교차 검증 + HTTPS |
+| `DEPOSIT_CALLBACK`       | payload의 `secret` 필드를 `payments.pg_response.secret`에 저장된 값과 비교                      |
+
+`TOSS_WEBHOOK_SECRET` 환경변수는 사용하지 않는다. Toss는 `PAYMENT_STATUS_CHANGED`에 HMAC 서명을 제공하지 않는다.
+
+### 5.5 `DEPOSIT_CALLBACK` 검증을 위한 secret 저장
+
+`DEPOSIT_CALLBACK` 검증에는 Toss confirm 응답의 `secret`이 필요하다. `confirm_payment` 흐름에서 Toss 응답의 최소 필드만 `payments.pg_response` jsonb에 저장한다.
+
+저장 필드:
+
+```jsonc
+{
+  "paymentKey": "<string>",
+  "orderId": "<string>",
+  "method": "<string>",
+  "status": "<string>",
+  "secret": "<string | null>", // 가상계좌 발급 시에만 존재
+}
+```
+
+카드번호, 계좌번호, 고객 식별성이 높은 상세 정보는 저장하지 않는다.
+
+### 5.6 Webhook Idempotency
+
+`tosspayments-webhook-transmission-id` 헤더를 `provider_event_id`로 저장하고, `(provider, provider_event_id)` unique index로 retry/중복 수신을 처리한다.
+
+처리 흐름 (T63 구현 기준):
+
+1. `provider_event_id` 중복 여부 확인 → 이미 존재하면 `200 OK` 반환 (멱등 처리)
+2. `payment_webhook_received` 이벤트 INSERT (`status='pending'`)
+3. 이벤트 타입별 처리 수행
+4. 처리 완료 후 `status='processed'`, `processed_at=now()` 갱신
+
+---
+
+## 6. T22 Realtime 구독 모델
+
+Supabase Realtime으로 `payment_events` 테이블 INSERT를 구독한다.
+
+| 소비자 유형 | 구독 채널 이벤트                                          | 사용 목적      |
+| ----------- | --------------------------------------------------------- | -------------- |
+| 소비자      | `payment_confirmed`                                       | 결제 성공 알림 |
+| 판매자      | `payment_confirmed`                                       | 신규 주문 알림 |
+| 관리자      | `payment_compensation_failed`, `payment_stuck_processing` | 운영 알람      |
+
+채널 필터는 `order_id` 또는 `store_id`(payload에 포함) 기준으로 격리한다. 구현 상세는 T22에서 결정한다.
+
+---
+
+## 7. 후속 구현 Task
+
+| Task | 내용                                                                                                                               | 선행 |
+| ---- | ---------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| T62  | `payment_events` 테이블 incremental migration + 공통 event contract + `confirm_payment` RPC 내부 `payment_confirmed` 이벤트 INSERT | T11  |
+| T63  | `POST /api/payments/webhook` Route Handler 구현 (검증, idempotency, event log 저장)                                                | T62  |
+| T43  | `processing` 잔류 주문 Cron 감지 및 `payment_stuck_processing` 이벤트 삽입                                                         | T62  |
+| T22  | Supabase Realtime `payment_events` INSERT 구독 기반 알림 구현                                                                      | T62  |
+| T31  | 주문 취소/환불 API 구현 (`payment_cancelled` 이벤트 atomic 기록 포함)                                                              | T62  |
+
+---
+
+## 8. 관련 문서
+
+- 결제 흐름 및 Option B 보상 정책: `docs/system_architecture.md` 7절
+- webhook endpoint 명세: `docs/api_spec.md` 6.5절
+- migration 정책: `docs/migration_policy.md`
+- 결제 서비스 구현: `src/app/api/payments/_lib/service.ts`
+- Toss adapter: `src/app/api/payments/_lib/toss.ts`

--- a/docs/system_architecture.md
+++ b/docs/system_architecture.md
@@ -406,7 +406,8 @@ sequenceDiagram
     - cancel 실패 → 결제 승인 상태 유지, 주문 `processing` 잔류 (운영 알람 대상)
     - cancel 성공 + revert 실패 → 결제 취소, 주문 `processing` 잔류 (운영 알람 대상)
   - `processing` 상태로 30분 이상 잔류하는 주문은 운영 알람 대상이며 수동 확인이 필요하다.
-  - 후속 고도화: T11 (outbox/webhook/idempotency), A-ORDER-01 `status=processing` filter (P1)
+  - 결제 이벤트 모델(outbox/webhook/idempotency) 설계: `docs/payment_event_design.md`. 구현은 T62(`payment_events` 테이블 migration + `payment_confirmed` 이벤트 INSERT), T63(webhook Route Handler)에서 진행한다.
+  - A-ORDER-01 `status=processing` filter 스펙: `docs/api_spec.md` 10.4절 (P1)
 
 ### 7.1 정산대행 설계 원칙
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -36,7 +36,7 @@ PickMa 심화 프로젝트 task의 공유 기준 문서다. `temp/`는 로컬 �
 | T08 | incremental migration 전환 결정                              | P0       | 완료    | 178          | 없음                    | [T08_incremental_migration_policy.md](T08_incremental_migration_policy.md)                                       |
 | T09 | 501 API 및 UI 노출 목록 정리                                 | P0       | 완료    | 201          | 없음                    | [T09_api_501_ui_exposure_inventory.md](T09_api_501_ui_exposure_inventory.md)                                     |
 | T10 | 판매자 운영 상태 정책 및 구현                                | P1       | 완료    | 205          | T08                     | [T10_seller_operation_status.md](T10_seller_operation_status.md)                                                 |
-| T11 | 결제 outbox/webhook/idempotency 설계                         | P1       | 진행 전 | 확인 필요    | T01                     | [T11_payment_outbox_webhook_idempotency.md](T11_payment_outbox_webhook_idempotency.md)                           |
+| T11 | 결제 outbox/webhook/idempotency 설계                         | P1       | 완료    | 209          | T01                     | [T11_payment_outbox_webhook_idempotency.md](T11_payment_outbox_webhook_idempotency.md)                           |
 | T12 | 공개 상품 목록 Server Component 초기 데이터 전환             | P1       | 완료    | 165          | T05                     | [T12_public_product_list_server_initial_data.md](T12_public_product_list_server_initial_data.md)                 |
 | T13 | 상품 상세 Server Component 초기 데이터 전환                  | P1       | 완료    | 167          | 없음                    | [T13_product_detail_server_initial_data.md](T13_product_detail_server_initial_data.md)                           |
 | T14 | seller/admin role-aware route guard 개선                     | P1       | 진행 전 | 확인 필요    | T07                     | [T14_role_aware_route_guard.md](T14_role_aware_route_guard.md)                                                   |
@@ -47,7 +47,7 @@ PickMa 심화 프로젝트 task의 공유 기준 문서다. `temp/`는 로컬 �
 | T19 | 문서 baseline 정합성 및 지속 갱신 규칙 정리                  | P0       | 완료    | 169          | 없음                    | [T19_documentation_consistency_update.md](T19_documentation_consistency_update.md)                               |
 | T20 | Route Handler `_lib` 횡단 import 정리                        | P1       | 진행 전 | 확인 필요    | 없음                    | [T20_route_handler_lib_import_cleanup.md](T20_route_handler_lib_import_cleanup.md)                               |
 | T21 | 지도 기반 조회 및 거리순 정렬                                | P2       | 진행 전 | 확인 필요    | T08, T05                | [T21_map_based_search_distance_sort.md](T21_map_based_search_distance_sort.md)                                   |
-| T22 | 실시간 알림 기반 설계 및 1차 구현                            | P2       | 진행 전 | 확인 필요    | T11                     | [T22_realtime_notification_foundation.md](T22_realtime_notification_foundation.md)                               |
+| T22 | 실시간 알림 기반 설계 및 1차 구현                            | P2       | 진행 전 | 확인 필요    | T11, T62                | [T22_realtime_notification_foundation.md](T22_realtime_notification_foundation.md)                               |
 | T23 | E2E 테스트 및 결제 팝업 모킹 전략                            | P2       | 진행 전 | 확인 필요    | T01, T02, T03, T04, T24 | [T23_e2e_payment_popup_mocking_strategy.md](T23_e2e_payment_popup_mocking_strategy.md)                           |
 | T24 | CI 기본 파이프라인 구축                                      | P1       | 완료    | 173          | 없음                    | [T24_ci_lint_test_pipeline.md](T24_ci_lint_test_pipeline.md)                                                     |
 | T25 | hook input Domain/UI 타입 분리                               | P2       | 진행 전 | 확인 필요    | T15                     | [T25_hook_input_domain_ui_type_split.md](T25_hook_input_domain_ui_type_split.md)                                 |
@@ -56,7 +56,7 @@ PickMa 심화 프로젝트 task의 공유 기준 문서다. `temp/`는 로컬 �
 | T28 | 판매자 상품 수정 진입점 결정 및 구현                         | P2       | 진행 전 | 확인 필요    | T15                     | [T28_seller_product_edit_entrypoint.md](T28_seller_product_edit_entrypoint.md)                                   |
 | T29 | 판매자 제출 문서 확인 UX 개선                                | P2       | 진행 전 | 확인 필요    | T06, T44, T61           | [T29_seller_document_review_ux.md](T29_seller_document_review_ux.md)                                             |
 | T30 | AI 추천 1차 설계                                             | P2       | 진행 전 | 확인 필요    | T25, T05                | [T30_ai_recommendation_first_design.md](T30_ai_recommendation_first_design.md)                                   |
-| T31 | 주문 취소/환불 API 구현                                      | P3       | 진행 전 | 확인 필요    | T11, T02                | [T31_order_cancel_refund_api.md](T31_order_cancel_refund_api.md)                                                 |
+| T31 | 주문 취소/환불 API 구현                                      | P3       | 진행 전 | 확인 필요    | T11, T02, T62           | [T31_order_cancel_refund_api.md](T31_order_cancel_refund_api.md)                                                 |
 | T32 | 정산/수수료 시스템 설계                                      | P3       | 진행 전 | 확인 필요    | T31                     | [T32_settlement_fee_system_design.md](T32_settlement_fee_system_design.md)                                       |
 | T33 | 네이티브 앱 결제 방식 재검토                                 | P3       | 진행 전 | 확인 필요    | T01                     | [T33_native_app_payment_review.md](T33_native_app_payment_review.md)                                             |
 | T34 | 리뷰/평점 도메인 설계                                        | P3       | 진행 전 | 확인 필요    | 없음                    | [T34_review_rating_domain_design.md](T34_review_rating_domain_design.md)                                         |
@@ -87,13 +87,15 @@ PickMa 심화 프로젝트 task의 공유 기준 문서다. `temp/`는 로컬 �
 | T59 | 소비자 찜 목록 화면 및 API 구현                              | P2       | 진행 전 | 확인 필요    | T15                     | [T59_consumer_wishlist_page.md](T59_consumer_wishlist_page.md)                                                   |
 | T60 | Auth 비밀번호 정책 강화                                      | P1       | 진행 전 | 확인 필요    | T27                     | [T60_auth_password_policy.md](T60_auth_password_policy.md)                                                       |
 | T61 | 판매자 신청 서류 문서 타입 정리 (신분증 제거 및 타입명 통일) | P1       | 완료    | 195          | T44                     | [T61_seller_id_card_removal.md](T61_seller_id_card_removal.md)                                                   |
+| T62 | payment_events 테이블 migration 및 이벤트 contract 구현      | P1       | 진행 전 | 확인 필요    | T11                     | [T62_payment_events_migration_contract.md](T62_payment_events_migration_contract.md)                             |
+| T63 | POST /api/payments/webhook Route Handler 구현                | P1       | 진행 전 | 확인 필요    | T62                     | [T63_payment_webhook_route_handler.md](T63_payment_webhook_route_handler.md)                                     |
 
 ## 추천 진행 흐름
 
 완료 task는 제외하고, `진행 중`과 `진행 전` task만 기준으로 정렬한다.
 
 1. 즉시 착수 가능한 P0: T03, T04
-2. P1 공통 기반과 정책 정리: T17, T18, T20, T11, T14, T15, T60, T58
+2. P1 공통 기반과 정책 정리: T17, T18, T20, T14, T15, T60, T58, T62, T63
 3. P1 차단 해소 후 핵심 API/화면 구현: T40, T45, T39, T51, T54, T53
 4. P2 기능 확장과 운영 기반: T43, T21, T22, T25, T26, T28, T29, T38, T59, T30, T23, T41
 5. 사용자 흐름별 UI/UX 및 접근성 개선: T46, T47, T48, T49

--- a/docs/tasks/T11_payment_outbox_webhook_idempotency.md
+++ b/docs/tasks/T11_payment_outbox_webhook_idempotency.md
@@ -1,10 +1,10 @@
 # T11. 결제 outbox/webhook/idempotency 설계
 
 - 상태:
-  진행 전
+  완료
 
 - GitHub Issue:
-  확인 필요
+  209
 
 - 우선순위:
   P1
@@ -49,3 +49,10 @@
 - 완료 기준:
   - 결제 이벤트/재시도/웹훅 설계 문서가 있다.
   - 추후 구현할 schema/API task가 분리되어 있다.
+
+- 구현 결과:
+  - 설계 문서: `docs/payment_event_design.md` (이벤트 모델, webhook 정책, idempotency 기준, T22 Realtime 구독 모델)
+  - `docs/api_spec.md` 6.5절: webhook 이벤트별 검증 방식, idempotency, 허용 이벤트/결제수단 구체화
+  - `docs/system_architecture.md` 7절: 이벤트 모델 참조 및 후속 task 명시
+  - 후속 구현 task: T62(`payment_events` migration + contract), T63(webhook Route Handler)
+  - T22/T31 선행 조건에 T62 추가

--- a/docs/tasks/T22_realtime_notification_foundation.md
+++ b/docs/tasks/T22_realtime_notification_foundation.md
@@ -10,7 +10,7 @@
   P2
 
 - 선행 조건:
-  - 선행 task: T11. 결제 outbox/webhook/idempotency 설계
+  - 선행 task: T11. 결제 outbox/webhook/idempotency 설계, T62. payment_events 테이블 migration 및 이벤트 contract 구현
 
 - 분류:
   기능
@@ -31,6 +31,7 @@
   이벤트/outbox 없이 realtime을 붙이면 잘못된 중간 상태나 재시도 상태가 사용자에게 전파될 수 있다.
 
 - 작업 내용:
+  - `payment_events` 테이블 INSERT 구독을 기반으로 채널 구조를 설계한다 (T62 완료 전제).
   - `notifications` 테이블 또는 Supabase Realtime 채널 구조를 설계한다.
   - 사용자별/판매자별 채널 구독 범위를 정한다.
   - 주문 접수, 준비 완료, 픽업 완료, 결제 실패/보정 필요 이벤트를 정의한다.

--- a/docs/tasks/T31_order_cancel_refund_api.md
+++ b/docs/tasks/T31_order_cancel_refund_api.md
@@ -10,7 +10,7 @@
   P3
 
 - 선행 조건:
-  - 선행 task: T11. 결제 outbox/webhook/idempotency 설계, T02. 판매자 주문 관리 real API 연결
+  - 선행 task: T11. 결제 outbox/webhook/idempotency 설계, T02. 판매자 주문 관리 real API 연결, T62. payment_events 테이블 migration 및 이벤트 contract 구현
 
 - 분류:
   기능
@@ -34,6 +34,7 @@
   - 취소 가능 상태와 시간 정책을 정한다.
   - `PATCH /api/orders/:id/cancel`, `POST /api/payments/:id/cancel`을 구현한다.
   - Toss cancel API 연동과 재고 복구를 atomic하게 처리한다.
+  - 취소 완료 시 `payment_cancelled` 이벤트를 `payment_events`에 atomic하게 기록한다 (T62 완료 전제).
   - 고객/관리자 UI에 취소/환불 상태를 표시한다.
 
 - 관련 파일/영역:

--- a/docs/tasks/T62_payment_events_migration_contract.md
+++ b/docs/tasks/T62_payment_events_migration_contract.md
@@ -1,0 +1,49 @@
+# T62. payment_events 테이블 migration 및 이벤트 contract 구현
+
+- 상태:
+  진행 전
+
+- GitHub Issue:
+  확인 필요
+
+- 우선순위:
+  P1
+
+- 선행 조건:
+  - 선행 task: T11. 결제 outbox/webhook/idempotency 설계
+
+- 분류:
+  구현
+
+- 사용자 흐름:
+  Customer / Seller / Admin
+
+- 주 담당 역할:
+  Architecture, Domain
+
+- 보조 역할:
+  Docs
+
+- 배경:
+  T11에서 결제 이벤트 모델 설계가 완료됐다. `payment_events` 테이블을 생성하고, 이벤트 타입을 공통 contract로 정의하며, 결제 확정 시 `payment_confirmed` 이벤트가 atomic하게 기록되도록 구현한다.
+
+- 작업 내용:
+  - `payment_events` 테이블 incremental migration 파일 작성 (`docs/payment_event_design.md` 2절 스키마 기준)
+  - `payment_events` 공통 event contract 정의 (`src/contracts/payment.ts` 또는 별도 `src/contracts/payment-event.ts`)
+  - `confirm_payment` DB RPC 내부에서 `payment_confirmed` 이벤트 INSERT (atomic)
+  - 중복 confirm 응답을 `PAYMENT_ALREADY_CONFIRMED`로 매핑할지 여부 결정 및 구현
+
+- 관련 파일/영역:
+  - `supabase/migrations/` (신규 migration)
+  - `src/contracts/payment.ts` 또는 `src/contracts/payment-event.ts`
+  - `supabase/functions/` 또는 DB RPC (`confirm_payment`)
+  - `docs/payment_event_design.md`
+
+- 예상 난이도:
+  중간
+
+- 완료 기준:
+  - `payment_events` 테이블이 migration으로 생성된다.
+  - 이벤트 타입이 공통 contract에 정의된다.
+  - 결제 확정 시 `payment_confirmed` 이벤트가 atomic하게 삽입된다.
+  - T22(Realtime 구독), T31(취소 이벤트), T43(Cron 감지)가 이 테이블을 사용할 수 있다.

--- a/docs/tasks/T62_payment_events_migration_contract.md
+++ b/docs/tasks/T62_payment_events_migration_contract.md
@@ -43,7 +43,7 @@
   중간
 
 - 완료 기준:
-  - `payment_events` 테이블이 migration으로 생성된다.
+  - `payment_events` 테이블이 migration으로 생성된다 (`store_id` column 포함).
   - 이벤트 타입이 공통 contract에 정의된다.
-  - 결제 확정 시 `payment_confirmed` 이벤트가 atomic하게 삽입된다.
+  - 결제 확정 시 `payment_confirmed` 이벤트가 `store_id`와 함께 atomic하게 삽입된다.
   - T22(Realtime 구독), T31(취소 이벤트), T43(Cron 감지)가 이 테이블을 사용할 수 있다.

--- a/docs/tasks/T63_payment_webhook_route_handler.md
+++ b/docs/tasks/T63_payment_webhook_route_handler.md
@@ -1,0 +1,53 @@
+# T63. POST /api/payments/webhook Route Handler 구현
+
+- 상태:
+  진행 전
+
+- GitHub Issue:
+  확인 필요
+
+- 우선순위:
+  P1
+
+- 선행 조건:
+  - 선행 task: T62. payment_events 테이블 migration 및 이벤트 contract 구현
+
+- 분류:
+  구현
+
+- 사용자 흐름:
+  Customer / Seller / Admin
+
+- 주 담당 역할:
+  Architecture
+
+- 보조 역할:
+  Domain
+
+- 배경:
+  T62에서 `payment_events` 테이블과 공통 event contract가 준비된다. T63에서는 Toss가 호출하는 webhook endpoint를 구현한다.
+
+- 작업 내용:
+  - `POST /api/payments/webhook` Route Handler 구현
+  - 이벤트별 검증 방식 구현:
+    - `PAYMENT_STATUS_CHANGED`: `orderNumber`, `amount`를 DB와 교차 검증 + HTTPS
+    - `DEPOSIT_CALLBACK`: payload `secret`을 `payments.pg_response.secret`과 비교
+  - Idempotency 처리: `tosspayments-webhook-transmission-id` → `provider_event_id`, `(provider, provider_event_id)` unique index로 중복 차단
+  - `payment_webhook_received` 이벤트 INSERT 및 처리 상태 갱신
+  - 허용 이벤트 타입: `PAYMENT_STATUS_CHANGED`, `DEPOSIT_CALLBACK`
+  - 허용 결제수단: `card`, `virtual_account`, `mobile`, `easy_pay`
+
+- 관련 파일/영역:
+  - `src/app/api/payments/webhook/route.ts` (신규)
+  - `src/app/api/payments/_lib/service.ts` 또는 `src/app/api/payments/webhook/_lib/`
+  - `src/contracts/payment-event.ts`
+  - `docs/payment_event_design.md` 5절
+
+- 예상 난이도:
+  중간
+
+- 완료 기준:
+  - Toss webhook 수신 시 이벤트별 검증을 통과한다.
+  - 중복 수신 시 `200 OK`를 반환한다 (멱등 처리).
+  - `payment_webhook_received` 이벤트가 `payment_events`에 기록된다.
+  - 처리 완료 시 `status='processed'`, `processed_at`이 갱신된다.

--- a/docs/tasks/T63_payment_webhook_route_handler.md
+++ b/docs/tasks/T63_payment_webhook_route_handler.md
@@ -30,8 +30,8 @@
 - 작업 내용:
   - `POST /api/payments/webhook` Route Handler 구현
   - 이벤트별 검증 방식 구현:
-    - `PAYMENT_STATUS_CHANGED`: `orderNumber`, `amount`를 DB와 교차 검증 + HTTPS
-    - `DEPOSIT_CALLBACK`: payload `secret`을 `payments.pg_response.secret`과 비교
+    - `PAYMENT_STATUS_CHANGED`: `body.data.orderId`(=orderNumber), `body.data.totalAmount`를 DB와 교차 검증 + HTTPS (body 구조: `{ eventType, createdAt, data: Payment객체 }`)
+    - `DEPOSIT_CALLBACK`: `body.secret`을 `payments.pg_response.secret`과 비교, `body.orderId`(=orderNumber)로 결제 조회 (body 구조: `{ createdAt, secret, status, orderId, transactionKey }`)
   - Idempotency 처리: `tosspayments-webhook-transmission-id` → `provider_event_id`, `(provider, provider_event_id)` unique index로 중복 차단
   - `payment_webhook_received` 이벤트 INSERT 및 처리 상태 갱신
   - 허용 이벤트 타입: `PAYMENT_STATUS_CHANGED`, `DEPOSIT_CALLBACK`


### PR DESCRIPTION
## 📌 작업 내용

- T11 결제 outbox/webhook/idempotency 설계를 문서화했습니다.
- `payment_events` 이벤트 로그 테이블 스키마, 이벤트 타입, INSERT 기본 status, Realtime 구독 필터 기준을 정리했습니다.
- Toss webhook 수신 정책을 이벤트별 body 구조와 검증 방식 기준으로 구체화했습니다.
- confirm idempotency 기준과 webhook idempotency 기준을 문서화했습니다.
- T01 보상 실패 이벤트를 `payment_compensation_failed`, `payment_stuck_processing` 운영 이벤트 모델로 통합했습니다.
- 후속 구현 task T62, T63을 분리하고 T22/T31 선행 조건을 갱신했습니다.

Task ID: T11

## 🔧 변경 사항

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서 수정

## 📚 문서/Task 반영

- [x] 관련 `docs/*` 최신화 필요 여부 확인
- [x] 필요한 문서 수정 반영 또는 후속 task/확인 필요로 기록
- [x] `docs/tasks` 상태와 GitHub Issue 번호 갱신

## 📂 주요 변경 파일

- `docs/payment_event_design.md`
- `docs/api_spec.md`
- `docs/system_architecture.md`
- `docs/tasks/README.md`
- `docs/tasks/T11_payment_outbox_webhook_idempotency.md`
- `docs/tasks/T22_realtime_notification_foundation.md`
- `docs/tasks/T31_order_cancel_refund_api.md`
- `docs/tasks/T62_payment_events_migration_contract.md`
- `docs/tasks/T63_payment_webhook_route_handler.md`

## 🧪 테스트 방법

- 순수 문서 변경이라 automated test는 실행하지 않았습니다.
- 수동 검증:
  - `docs/payment_event_design.md`와 `docs/api_spec.md` 6.5절의 webhook body/검증/idempotency 정책 교차 확인
  - `docs/system_architecture.md` 7절의 결제 보상 정책과 이벤트 모델 참조 확인
  - `docs/tasks/README.md`와 T11/T22/T31/T62/T63 개별 task 문서의 상태/선행 조건 정합성 확인
  - Toss Payments 공식 webhook 이벤트 문서 기준으로 `PAYMENT_STATUS_CHANGED`, `DEPOSIT_CALLBACK` body 구조 확인

## 📸 스크린샷 (선택)

- 문서 변경이라 해당 없음

## 🔗 관련 이슈

- close #209
