### PR TITLE
refactor: hook 입력 타입 경계 분리

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -50,7 +50,7 @@ PickMa 심화 프로젝트 task의 공유 기준 문서다. `temp/`는 로컬 �
 | T22 | 실시간 알림 기반 설계 및 1차 구현                            | P2       | 진행 전 | 확인 필요    | T11, T62                     | [T22_realtime_notification_foundation.md](T22_realtime_notification_foundation.md)                               |
 | T23 | E2E 테스트 및 결제 팝업 모킹 전략                            | P2       | 진행 전 | 확인 필요    | T01, T02, T03, T04, T24      | [T23_e2e_payment_popup_mocking_strategy.md](T23_e2e_payment_popup_mocking_strategy.md)                           |
 | T24 | CI 기본 파이프라인 구축                                      | P1       | 완료    | 173          | 없음                         | [T24_ci_lint_test_pipeline.md](T24_ci_lint_test_pipeline.md)                                                     |
-| T25 | hook input Domain/UI 타입 분리                               | P2       | 진행 전 | 확인 필요    | T15                          | [T25_hook_input_domain_ui_type_split.md](T25_hook_input_domain_ui_type_split.md)                                 |
+| T25 | hook input Domain/UI 타입 분리                               | P2       | 완료    | 252          | T15                          | [T25_hook_input_domain_ui_type_split.md](T25_hook_input_domain_ui_type_split.md)                                 |
 | T26 | 운영 화면 summary/list API 분리                              | P2       | 진행 전 | 확인 필요    | T04                          | [T26_admin_seller_summary_list_api_split.md](T26_admin_seller_summary_list_api_split.md)                         |
 | T27 | Auth 이메일/Supabase SMTP/rate limit 정책 정리               | P0       | 완료    | 186          | 없음                         | [T27_auth_email_smtp_rate_limit_policy.md](T27_auth_email_smtp_rate_limit_policy.md)                             |
 | T28 | 판매자 상품 수정 진입점 결정 및 구현                         | P2       | 완료    | 229          | T15                          | [T28_seller_product_edit_entrypoint.md](T28_seller_product_edit_entrypoint.md)                                   |
@@ -101,7 +101,7 @@ PickMa 심화 프로젝트 task의 공유 기준 문서다. `temp/`는 로컬 �
 완료 task는 제외하고, `진행 중`과 `진행 전` task만 기준으로 정렬한다.
 
 1. P1 기반/운영 차단 해소: T39
-2. P1/P2 독립 기반 작업: T26, T25
+2. P1/P2 독립 기반 작업: T26
 3. 기능 확장: T22, T59, T30, T23
 4. 공통 컴포넌트 접근성 및 폴더 통일 (T46~T49 선행 필수): T64, T65
 5. UI/UX 개선 묶음: T46, T47, T48, T49

--- a/docs/tasks/T25_hook_input_domain_ui_type_split.md
+++ b/docs/tasks/T25_hook_input_domain_ui_type_split.md
@@ -1,10 +1,10 @@
 # T25. hook input Domain/UI 타입 분리
 
 - 상태:
-  진행 전
+  완료
 
 - GitHub Issue:
-  확인 필요
+  252
 
 - 우선순위:
   P2
@@ -48,3 +48,10 @@
 - 완료 기준:
   - 주요 mutation hook 외부 props가 Contract DTO에 직접 결합되지 않는다.
   - 변환 책임이 API boundary에 위치한다.
+
+- 구현 결과:
+  - `src/types/*`에 주문 생성, 결제 확인, 상품 목록 query, 판매자 상품 생성/수정, 메뉴 생성/수정, 스토어 생성/수정, 사용자 정보 수정, 판매자 신청 입력 타입을 추가했다.
+  - `src/hooks/**`의 주요 mutation/query 입력에서 Contract request 타입 직접 노출을 제거하고 Domain/UI 타입을 사용하도록 정리했다.
+  - `src/api/**` client wrapper에서 Domain/UI 입력을 Contract DTO로 변환한 뒤 request body/query로 전달하도록 이동했다.
+  - Date 기반 입력(`pickupAt`, `endAt`)은 API boundary에서 ISO string으로 변환하도록 고정했다.
+  - 주문/결제/판매자 상품/스토어 API 테스트와 관련 hook 테스트로 변환 경로를 검증했다.

--- a/src/api/orders/orderApi.test.ts
+++ b/src/api/orders/orderApi.test.ts
@@ -37,9 +37,14 @@ describe('orderApi.createOrder', () => {
     const result = await orderApi.createOrder({
       productId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
       quantity: 2,
-      pickupAt: '2026-05-11T11:00:00.000Z',
+      pickupAt: new Date('2026-05-11T11:00:00.000Z'),
     });
 
+    expect(apiClient.post).toHaveBeenCalledWith('/api/orders', {
+      productId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      quantity: 2,
+      pickupAt: '2026-05-11T11:00:00.000Z',
+    });
     expect(result).toEqual({
       id: 'order-1',
       orderNumber: 'PM20260511A1B2C3D4E5',
@@ -58,7 +63,7 @@ describe('orderApi.createOrder', () => {
       orderApi.createOrder({
         productId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
         quantity: 1,
-        pickupAt: '2026-05-11T11:00:00.000Z',
+        pickupAt: new Date('2026-05-11T11:00:00.000Z'),
       })
     ).rejects.toBe(error);
   });

--- a/src/api/orders/orderApi.ts
+++ b/src/api/orders/orderApi.ts
@@ -1,5 +1,11 @@
 import type { PaginatedResult } from '@/types/common';
-import type { CreatedOrderPaymentInfo, Order } from '@/types/order';
+import type {
+  ConsumerOrderListQuery,
+  CreatedOrderPaymentInfo,
+  CreateOrderInput,
+  Order,
+  OrderStatus,
+} from '@/types/order';
 import type {
   ConsumerOrderListParams,
   CreateOrderRequest,
@@ -11,10 +17,40 @@ import type {
 import { apiClient } from '../apiClient';
 import { mapOrder, mapOrderListItem } from './orderMapper';
 
+const ORDER_STATUS_TO_PARAM = {
+  paymentPending: 'payment_pending',
+  reserved: 'reserved',
+  ready: 'ready',
+  completed: 'completed',
+  cancelled: 'cancelled',
+  cancelling: 'cancelling',
+  noShow: 'no_show',
+  expired: 'expired',
+} satisfies Record<
+  Exclude<OrderStatus, 'accepted' | 'processing'>,
+  ConsumerOrderListParams['status']
+>;
+
+function toCreateOrderRequest(input: CreateOrderInput): CreateOrderRequest {
+  return {
+    ...input,
+    pickupAt: input.pickupAt.toISOString(),
+  };
+}
+
+function toConsumerOrderListParams(
+  query: ConsumerOrderListQuery
+): ConsumerOrderListParams {
+  return {
+    ...query,
+    status: query.status ? ORDER_STATUS_TO_PARAM[query.status] : undefined,
+  };
+}
+
 export const orderApi = {
-  createOrder(body: CreateOrderRequest): Promise<CreatedOrderPaymentInfo> {
+  createOrder(input: CreateOrderInput): Promise<CreatedOrderPaymentInfo> {
     return apiClient
-      .post<CreateOrderResponse>('/api/orders', body)
+      .post<CreateOrderResponse>('/api/orders', toCreateOrderRequest(input))
       .then((res) => ({
         id: res.id,
         orderNumber: res.orderNumber,
@@ -25,10 +61,10 @@ export const orderApi = {
   },
 
   getOrders(
-    params: ConsumerOrderListParams
+    query: ConsumerOrderListQuery
   ): Promise<PaginatedResult<Omit<Order, 'items' | 'payment'>>> {
     return apiClient
-      .get<OrderListResponse>('/api/orders', params)
+      .get<OrderListResponse>('/api/orders', toConsumerOrderListParams(query))
       .then((res) => ({ ...res, items: res.items.map(mapOrderListItem) }));
   },
 

--- a/src/api/payments/paymentApi.test.ts
+++ b/src/api/payments/paymentApi.test.ts
@@ -42,3 +42,25 @@ describe('paymentApi.cancelPayment', () => {
     expect(result).toBeUndefined();
   });
 });
+
+describe('paymentApi.confirmPayment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('confirmPayment는 결제 확인 입력을 contract body로 전달한다', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue(undefined);
+
+    await paymentApi.confirmPayment({
+      paymentKey: 'payment-key-1',
+      orderNumber: 'PM20260611A1B2C3',
+      amount: 7200,
+    });
+
+    expect(apiClient.post).toHaveBeenCalledWith('/api/payments/confirm', {
+      paymentKey: 'payment-key-1',
+      orderNumber: 'PM20260611A1B2C3',
+      amount: 7200,
+    });
+  });
+});

--- a/src/api/payments/paymentApi.ts
+++ b/src/api/payments/paymentApi.ts
@@ -1,4 +1,9 @@
 import type {
+  CancelPaymentInput,
+  ConfirmPaymentInput,
+  PreparePaymentInput,
+} from '@/types/payment';
+import type {
   CancelPaymentRequest,
   ConfirmPaymentRequest,
   PreparePaymentRequest,
@@ -7,20 +12,44 @@ import type {
 
 import { apiClient } from '../apiClient';
 
+function toPreparePaymentRequest(
+  input: PreparePaymentInput
+): PreparePaymentRequest {
+  return { ...input };
+}
+
+function toConfirmPaymentRequest(
+  input: ConfirmPaymentInput
+): ConfirmPaymentRequest {
+  return { ...input };
+}
+
+function toCancelPaymentRequest(
+  input: CancelPaymentInput
+): CancelPaymentRequest {
+  return { ...input };
+}
+
 export const paymentApi = {
-  preparePayment(body: PreparePaymentRequest): Promise<PreparePaymentResponse> {
+  preparePayment(input: PreparePaymentInput): Promise<PreparePaymentResponse> {
     return apiClient.post<PreparePaymentResponse>(
       '/api/payments/prepare',
-      body
+      toPreparePaymentRequest(input)
     );
   },
-  confirmPayment(body: ConfirmPaymentRequest): Promise<void> {
-    return apiClient.post<void>('/api/payments/confirm', body);
+  confirmPayment(input: ConfirmPaymentInput): Promise<void> {
+    return apiClient.post<void>(
+      '/api/payments/confirm',
+      toConfirmPaymentRequest(input)
+    );
   },
 
-  cancelPayment(paymentId: string, body: CancelPaymentRequest): Promise<void> {
+  cancelPayment(paymentId: string, input: CancelPaymentInput): Promise<void> {
     return apiClient
-      .post<void>(`/api/payments/${paymentId}/cancel`, body)
+      .post<void>(
+        `/api/payments/${paymentId}/cancel`,
+        toCancelPaymentRequest(input)
+      )
       .then(() => undefined);
   },
 };

--- a/src/api/products/productApi.ts
+++ b/src/api/products/productApi.ts
@@ -1,17 +1,50 @@
 import type { PaginatedResult } from '@/types/common';
-import type { Product, ProductDetail, ProductListQuery } from '@/types/product';
+import type {
+  Product,
+  ProductDetail,
+  ProductDiscountOption,
+  ProductListQuery,
+} from '@/types/product';
 import type {
   ProductDetailResponse,
+  ProductListParams,
   ProductListResponse,
 } from '@/contracts/product';
 
 import { apiClient } from '../apiClient';
 import { mapProduct, mapProductDetail } from './productMapper';
 
+const PRODUCT_DISCOUNT_OPTION_TO_PARAM = {
+  all: 'all',
+  'over-40': 'over-40',
+  '30-to-40': '30-to-40',
+  '20-to-30': '20-to-30',
+  'under-20': 'under-20',
+} satisfies Record<ProductDiscountOption, ProductListParams['discountOption']>;
+
+function toProductListParams(query: ProductListQuery): ProductListParams {
+  return {
+    page: query.page,
+    pageSize: query.pageSize,
+    userLat: query.userLat,
+    userLng: query.userLng,
+    categoryId: query.categoryId,
+    keyword: query.keyword,
+    minPrice: query.minPrice,
+    maxPrice: query.maxPrice,
+    discountOption: query.discountOption
+      ? PRODUCT_DISCOUNT_OPTION_TO_PARAM[query.discountOption]
+      : undefined,
+    sort: query.sort,
+    order: query.order,
+    availableOnly: query.availableOnly,
+  };
+}
+
 export const productApi = {
   getProducts(query: ProductListQuery): Promise<PaginatedResult<Product>> {
     return apiClient
-      .get<ProductListResponse>('/api/products', query)
+      .get<ProductListResponse>('/api/products', toProductListParams(query))
       .then((res) => ({ ...res, items: res.items.map(mapProduct) }));
   },
 

--- a/src/api/products/productApi.ts
+++ b/src/api/products/productApi.ts
@@ -1,8 +1,7 @@
 import type { PaginatedResult } from '@/types/common';
-import type { Product, ProductDetail } from '@/types/product';
+import type { Product, ProductDetail, ProductListQuery } from '@/types/product';
 import type {
   ProductDetailResponse,
-  ProductListParams,
   ProductListResponse,
 } from '@/contracts/product';
 
@@ -10,9 +9,9 @@ import { apiClient } from '../apiClient';
 import { mapProduct, mapProductDetail } from './productMapper';
 
 export const productApi = {
-  getProducts(params: ProductListParams): Promise<PaginatedResult<Product>> {
+  getProducts(query: ProductListQuery): Promise<PaginatedResult<Product>> {
     return apiClient
-      .get<ProductListResponse>('/api/products', params)
+      .get<ProductListResponse>('/api/products', query)
       .then((res) => ({ ...res, items: res.items.map(mapProduct) }));
   },
 

--- a/src/api/seller-applications/sellerApplicationApi.ts
+++ b/src/api/seller-applications/sellerApplicationApi.ts
@@ -1,4 +1,7 @@
-import type { SellerApplication } from '@/types/seller-application';
+import type {
+  CreateSellerApplicationPayload,
+  SellerApplication,
+} from '@/types/seller-application';
 import type {
   CreateSellerApplicationRequest,
   SellerApplicationDocumentReadUrlResponse,
@@ -8,12 +11,21 @@ import { apiClient } from '@/api/apiClient';
 
 import { mapSellerApplication } from './sellerApplicationMapper';
 
+function toCreateSellerApplicationRequest(
+  input: CreateSellerApplicationPayload
+): CreateSellerApplicationRequest {
+  return { ...input };
+}
+
 export const sellerApplicationApi = {
   createSellerApplication(
-    body: CreateSellerApplicationRequest
+    input: CreateSellerApplicationPayload
   ): Promise<SellerApplication> {
     return apiClient
-      .post<SellerApplicationResponse>('/api/seller-applications', body)
+      .post<SellerApplicationResponse>(
+        '/api/seller-applications',
+        toCreateSellerApplicationRequest(input)
+      )
       .then(mapSellerApplication);
   },
 

--- a/src/api/seller/menu-items/sellerMenuItemApi.ts
+++ b/src/api/seller/menu-items/sellerMenuItemApi.ts
@@ -1,4 +1,9 @@
-import type { MenuItem } from '@/types/menu-item';
+import type {
+  CreateMenuItemInput,
+  MenuItem,
+  SellerMenuItemListQuery,
+  UpdateMenuItemInput,
+} from '@/types/menu-item';
 import type {
   CreateMenuItemRequest,
   MenuItemResponse,
@@ -9,22 +14,48 @@ import { apiClient } from '@/api/apiClient';
 
 import { mapMenuItem } from './sellerMenuItemMapper';
 
+function toSellerMenuItemListParams(
+  query?: SellerMenuItemListQuery
+): SellerMenuItemListParams | undefined {
+  return query ? { ...query } : undefined;
+}
+
+function toCreateMenuItemRequest(
+  input: CreateMenuItemInput
+): CreateMenuItemRequest {
+  return { ...input };
+}
+
+function toUpdateMenuItemRequest(
+  input: UpdateMenuItemInput
+): UpdateMenuItemRequest {
+  return { ...input };
+}
+
 export const sellerMenuItemApi = {
-  getMenuItems(params?: SellerMenuItemListParams): Promise<MenuItem[]> {
+  getMenuItems(query?: SellerMenuItemListQuery): Promise<MenuItem[]> {
     return apiClient
-      .get<MenuItemResponse[]>('/api/seller/menu-items', params)
+      .get<
+        MenuItemResponse[]
+      >('/api/seller/menu-items', toSellerMenuItemListParams(query))
       .then((items) => items.map(mapMenuItem));
   },
 
-  createMenuItem(body: CreateMenuItemRequest): Promise<MenuItem> {
+  createMenuItem(input: CreateMenuItemInput): Promise<MenuItem> {
     return apiClient
-      .post<MenuItemResponse>('/api/seller/menu-items', body)
+      .post<MenuItemResponse>(
+        '/api/seller/menu-items',
+        toCreateMenuItemRequest(input)
+      )
       .then(mapMenuItem);
   },
 
-  updateMenuItem(id: string, body: UpdateMenuItemRequest): Promise<MenuItem> {
+  updateMenuItem(id: string, input: UpdateMenuItemInput): Promise<MenuItem> {
     return apiClient
-      .patch<MenuItemResponse>(`/api/seller/menu-items/${id}`, body)
+      .patch<MenuItemResponse>(
+        `/api/seller/menu-items/${id}`,
+        toUpdateMenuItemRequest(input)
+      )
       .then(mapMenuItem);
   },
 

--- a/src/api/seller/orders/sellerOrderApi.ts
+++ b/src/api/seller/orders/sellerOrderApi.ts
@@ -1,5 +1,5 @@
 import type { PaginatedResult } from '@/types/common';
-import type { Order } from '@/types/order';
+import type { Order, OrderStatus, SellerOrderListQuery } from '@/types/order';
 import type {
   OrderDetailResponse,
   OrderListResponse,
@@ -9,12 +9,42 @@ import { apiClient } from '@/api/apiClient';
 
 import { mapSellerOrder, mapSellerOrderListItem } from './sellerOrderMapper';
 
+const ORDER_STATUS_TO_PARAM: Record<
+  Exclude<OrderStatus, 'paymentPending' | 'processing'>,
+  SellerOrderListParams['status']
+> = {
+  reserved: 'reserved',
+  accepted: 'accepted',
+  ready: 'ready',
+  completed: 'completed',
+  cancelled: 'cancelled',
+  cancelling: 'cancelling',
+  noShow: 'no_show',
+  expired: 'expired',
+};
+
+function toSellerOrderListParams(
+  query?: Partial<SellerOrderListQuery>
+): Partial<SellerOrderListParams> | undefined {
+  if (!query) {
+    return undefined;
+  }
+
+  return {
+    ...query,
+    status: query.status ? ORDER_STATUS_TO_PARAM[query.status] : undefined,
+  };
+}
+
 export const sellerOrderApi = {
   getOrders(
-    params?: Partial<SellerOrderListParams>
+    query?: Partial<SellerOrderListQuery>
   ): Promise<PaginatedResult<Omit<Order, 'items' | 'payment'>>> {
     return apiClient
-      .get<OrderListResponse>('/api/seller/orders', params)
+      .get<OrderListResponse>(
+        '/api/seller/orders',
+        toSellerOrderListParams(query)
+      )
       .then((res) => ({
         ...res,
         items: res.items.map(mapSellerOrderListItem),

--- a/src/api/seller/products/sellerProductApi.test.ts
+++ b/src/api/seller/products/sellerProductApi.test.ts
@@ -50,30 +50,36 @@ describe('sellerProductApi', () => {
 
   it('createProduct는 request body를 전달하고 mapper 결과를 반환한다', async () => {
     vi.mocked(apiClient.post).mockResolvedValue(dto);
-    const body = {
+    const input = {
       menuItemId: 'menu-item-1',
       discountPrice: 7200,
       stock: 8,
-      endAt: '2099-12-31T23:59:59.000Z',
+      endAt: new Date('2099-12-31T23:59:59.000Z'),
       pickupStartTime: '10:00:00',
       pickupEndTime: '13:30:00',
     };
 
-    const result = await sellerProductApi.createProduct(body);
+    const result = await sellerProductApi.createProduct(input);
 
-    expect(apiClient.post).toHaveBeenCalledWith('/api/seller/products', body);
+    expect(apiClient.post).toHaveBeenCalledWith('/api/seller/products', {
+      ...input,
+      endAt: '2099-12-31T23:59:59.000Z',
+    });
     expect(result).toBe(product);
   });
 
   it('updateProduct는 product id 경로와 request body를 전달한다', async () => {
     vi.mocked(apiClient.patch).mockResolvedValue(dto);
-    const body = { stock: 5 };
+    const input = {
+      stock: 5,
+      endAt: new Date('2099-12-31T23:59:59.000Z'),
+    };
 
-    const result = await sellerProductApi.updateProduct('product-1', body);
+    const result = await sellerProductApi.updateProduct('product-1', input);
 
     expect(apiClient.patch).toHaveBeenCalledWith(
       '/api/seller/products/product-1',
-      body
+      { stock: 5, endAt: '2099-12-31T23:59:59.000Z' }
     );
     expect(result).toBe(product);
   });

--- a/src/api/seller/products/sellerProductApi.ts
+++ b/src/api/seller/products/sellerProductApi.ts
@@ -1,4 +1,8 @@
-import type { Product } from '@/types/product';
+import type {
+  CreateSellerProductInput,
+  Product,
+  UpdateSellerProductInput,
+} from '@/types/product';
 import type {
   CreateSellerProductRequest,
   ProductListItemResponse,
@@ -7,6 +11,24 @@ import type {
 import { apiClient } from '@/api/apiClient';
 
 import { mapSellerProduct } from './sellerProductMapper';
+
+function toCreateSellerProductRequest(
+  input: CreateSellerProductInput
+): CreateSellerProductRequest {
+  return {
+    ...input,
+    endAt: input.endAt.toISOString(),
+  };
+}
+
+function toUpdateSellerProductRequest(
+  input: UpdateSellerProductInput
+): UpdateSellerProductRequest {
+  return {
+    ...input,
+    endAt: input.endAt?.toISOString(),
+  };
+}
 
 export const sellerProductApi = {
   getProducts(): Promise<Product[]> {
@@ -21,18 +43,21 @@ export const sellerProductApi = {
       .then(mapSellerProduct);
   },
 
-  createProduct(body: CreateSellerProductRequest): Promise<Product> {
+  createProduct(input: CreateSellerProductInput): Promise<Product> {
     return apiClient
-      .post<ProductListItemResponse>('/api/seller/products', body)
+      .post<ProductListItemResponse>(
+        '/api/seller/products',
+        toCreateSellerProductRequest(input)
+      )
       .then(mapSellerProduct);
   },
 
-  updateProduct(
-    id: string,
-    body: UpdateSellerProductRequest
-  ): Promise<Product> {
+  updateProduct(id: string, input: UpdateSellerProductInput): Promise<Product> {
     return apiClient
-      .patch<ProductListItemResponse>(`/api/seller/products/${id}`, body)
+      .patch<ProductListItemResponse>(
+        `/api/seller/products/${id}`,
+        toUpdateSellerProductRequest(input)
+      )
       .then(mapSellerProduct);
   },
 

--- a/src/api/stores/storeApi.test.ts
+++ b/src/api/stores/storeApi.test.ts
@@ -81,3 +81,48 @@ describe('storeApi.getMyStore', () => {
     await expect(storeApi.getMyStore()).rejects.toBe(error);
   });
 });
+
+describe('storeApi mutations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(mapMyStore).mockReturnValue(mockMyStore);
+  });
+
+  it('createStore는 CreateStoreInput을 request body로 전달한다', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue(mockStoreResponse);
+
+    const result = await storeApi.createStore({
+      name: '픽마 베이커리',
+      businessNumber: '123-45-67890',
+      phone: '02-1234-5678',
+      address: '서울시 마포구 월드컵북로 12',
+      region: '서울 마포구',
+      image: 'stores/store-1.png',
+    });
+
+    expect(apiClient.post).toHaveBeenCalledWith('/api/stores', {
+      name: '픽마 베이커리',
+      businessNumber: '123-45-67890',
+      phone: '02-1234-5678',
+      address: '서울시 마포구 월드컵북로 12',
+      region: '서울 마포구',
+      image: 'stores/store-1.png',
+    });
+    expect(result).toBe(mockMyStore);
+  });
+
+  it('updateStore는 UpdateStoreInput을 request body로 전달한다', async () => {
+    vi.mocked(apiClient.patch).mockResolvedValue(mockStoreResponse);
+
+    const result = await storeApi.updateStore({
+      name: '수정된 가게',
+      operationStatus: 'closed',
+    });
+
+    expect(apiClient.patch).toHaveBeenCalledWith('/api/stores/me', {
+      name: '수정된 가게',
+      operationStatus: 'closed',
+    });
+    expect(result).toBe(mockMyStore);
+  });
+});

--- a/src/api/stores/storeApi.ts
+++ b/src/api/stores/storeApi.ts
@@ -1,4 +1,8 @@
-import type { MyStore } from '@/types/store';
+import type {
+  CreateStoreInput,
+  MyStore,
+  UpdateStoreInput,
+} from '@/types/store';
 import type {
   CreateStoreRequest,
   StoreResponse,
@@ -8,14 +12,24 @@ import type {
 import { ApiError, apiClient } from '../apiClient';
 import { mapMyStore } from './storeMapper';
 
+function toCreateStoreRequest(input: CreateStoreInput): CreateStoreRequest {
+  return { ...input };
+}
+
+function toUpdateStoreRequest(input: UpdateStoreInput): UpdateStoreRequest {
+  return { ...input };
+}
+
 export const storeApi = {
-  createStore(body: CreateStoreRequest): Promise<MyStore> {
-    return apiClient.post<StoreResponse>('/api/stores', body).then(mapMyStore);
+  createStore(input: CreateStoreInput): Promise<MyStore> {
+    return apiClient
+      .post<StoreResponse>('/api/stores', toCreateStoreRequest(input))
+      .then(mapMyStore);
   },
 
-  updateStore(body: UpdateStoreRequest): Promise<MyStore> {
+  updateStore(input: UpdateStoreInput): Promise<MyStore> {
     return apiClient
-      .patch<StoreResponse>('/api/stores/me', body)
+      .patch<StoreResponse>('/api/stores/me', toUpdateStoreRequest(input))
       .then(mapMyStore);
   },
 

--- a/src/api/users/userApi.ts
+++ b/src/api/users/userApi.ts
@@ -1,16 +1,22 @@
-import type { User } from '@/types/user';
+import type { UpdateMeInput, User } from '@/types/user';
 import type { UpdateMeRequest, UserResponse } from '@/contracts/user';
 
 import { apiClient } from '../apiClient';
 import { mapUser } from './userMapper';
+
+function toUpdateMeRequest(input: UpdateMeInput): UpdateMeRequest {
+  return { ...input };
+}
 
 export const userApi = {
   getMe(): Promise<User> {
     return apiClient.get<UserResponse>('/api/users/me').then(mapUser);
   },
 
-  updateMe(data: UpdateMeRequest): Promise<User> {
-    return apiClient.patch<UserResponse>('/api/users/me', data).then(mapUser);
+  updateMe(input: UpdateMeInput): Promise<User> {
+    return apiClient
+      .patch<UserResponse>('/api/users/me', toUpdateMeRequest(input))
+      .then(mapUser);
   },
 
   deleteMe(): Promise<void> {

--- a/src/app/(seller)/seller/products/[id]/edit/page.tsx
+++ b/src/app/(seller)/seller/products/[id]/edit/page.tsx
@@ -22,7 +22,7 @@ export default function SellerProductEditPage() {
         body: {
           discountPrice: Number(data.discountPrice),
           stock: Number(data.stock),
-          endAt: new Date(data.endAt).toISOString(),
+          endAt: new Date(data.endAt),
           pickupStartTime: data.pickupStartTime,
           pickupEndTime: data.pickupEndTime,
           status: data.status,

--- a/src/components/consumer/order/OrderCheckoutPanel.tsx
+++ b/src/components/consumer/order/OrderCheckoutPanel.tsx
@@ -47,7 +47,7 @@ function getPickupPlace(product: ProductDetail) {
 function createPickupAt(
   pickupBaseDateTime: string,
   pickupTime: PickupTimeOption
-) {
+): Date | null {
   const [hour, minute] = pickupTime.startAt.split(':').map(Number);
 
   if (
@@ -79,7 +79,7 @@ function createPickupAt(
     0
   );
 
-  return pickupAt.toISOString();
+  return pickupAt;
 }
 
 export function OrderCheckoutPanel({

--- a/src/components/seller/orders/OrderManageContent.tsx
+++ b/src/components/seller/orders/OrderManageContent.tsx
@@ -16,7 +16,6 @@ import type {
   SellerOrderActionStatus,
   SellerOrderDisplayStatus,
 } from '@/types/seller-order';
-import type { SellerOrderListParams } from '@/contracts/order';
 import { useAcceptSellerOrder } from '@/hooks/seller/orders/useAcceptSellerOrder';
 import { useCompleteSellerOrder } from '@/hooks/seller/orders/useCompleteSellerOrder';
 import { useMarkSellerOrderReady } from '@/hooks/seller/orders/useMarkSellerOrderReady';
@@ -27,19 +26,6 @@ import { OrderFilter } from './OrderFilter';
 import { OrderTable } from './OrderTable';
 
 type SellerOrderFilterStatus = SellerOrderDisplayStatus | '전체';
-
-const DOMAIN_TO_CONTRACT_STATUS: Record<
-  SellerOrderDisplayStatus,
-  Exclude<SellerOrderListParams['status'], undefined>
-> = {
-  reserved: 'reserved',
-  accepted: 'accepted',
-  ready: 'ready',
-  completed: 'completed',
-  cancelling: 'cancelling',
-  cancelled: 'cancelled',
-  noShow: 'no_show',
-};
 
 const VALID_STATUSES: SellerOrderDisplayStatus[] = [
   'reserved',
@@ -130,10 +116,7 @@ export function OrderManageContent() {
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionSuccess, setActionSuccess] = useState<string | null>(null);
 
-  const serverStatus =
-    selectedStatus === '전체'
-      ? undefined
-      : DOMAIN_TO_CONTRACT_STATUS[selectedStatus];
+  const serverStatus = selectedStatus === '전체' ? undefined : selectedStatus;
 
   const { data: totalData } = useSellerOrders({
     page: 1,

--- a/src/hooks/orders/useCreateOrder.ts
+++ b/src/hooks/orders/useCreateOrder.ts
@@ -2,16 +2,15 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import type { CreatedOrderPaymentInfo } from '@/types/order';
-import type { CreateOrderRequest } from '@/contracts/order';
+import type { CreatedOrderPaymentInfo, CreateOrderInput } from '@/types/order';
 import { invalidateTargets } from '@/lib/queryKeys';
 import { orderApi } from '@/api/orders/orderApi';
 
 export function useCreateOrder() {
   const queryClient = useQueryClient();
 
-  return useMutation<CreatedOrderPaymentInfo, Error, CreateOrderRequest>({
-    mutationFn: (body) => orderApi.createOrder(body),
+  return useMutation<CreatedOrderPaymentInfo, Error, CreateOrderInput>({
+    mutationFn: (input) => orderApi.createOrder(input),
     onSuccess: () => {
       invalidateTargets.afterCreateOrder.forEach((queryKey) => {
         void queryClient.invalidateQueries({ queryKey });

--- a/src/hooks/orders/useOrders.ts
+++ b/src/hooks/orders/useOrders.ts
@@ -3,40 +3,13 @@
 import { useQuery } from '@tanstack/react-query';
 
 import type { PaginatedResult } from '@/types/common';
-import type { ConsumerOrderListQuery, Order, OrderStatus } from '@/types/order';
-import type {
-  ConsumerOrderListParams,
-  OrderStatusParam,
-} from '@/contracts/order';
+import type { ConsumerOrderListQuery, Order } from '@/types/order';
 import { queryKeys } from '@/lib/queryKeys';
 import { orderApi } from '@/api/orders/orderApi';
-
-const ORDER_STATUS_TO_PARAM: Record<
-  Exclude<OrderStatus, 'accepted' | 'processing'>,
-  Exclude<OrderStatusParam, 'accepted' | 'processing'>
-> = {
-  paymentPending: 'payment_pending',
-  reserved: 'reserved',
-  ready: 'ready',
-  completed: 'completed',
-  cancelled: 'cancelled',
-  cancelling: 'cancelling',
-  noShow: 'no_show',
-  expired: 'expired',
-};
-
-function toOrderListParams(
-  query: ConsumerOrderListQuery
-): ConsumerOrderListParams {
-  return {
-    ...query,
-    status: query.status ? ORDER_STATUS_TO_PARAM[query.status] : undefined,
-  };
-}
 
 export function useOrders(query: ConsumerOrderListQuery) {
   return useQuery<PaginatedResult<Omit<Order, 'items' | 'payment'>>>({
     queryKey: queryKeys.orders.list(query),
-    queryFn: () => orderApi.getOrders(toOrderListParams(query)),
+    queryFn: () => orderApi.getOrders(query),
   });
 }

--- a/src/hooks/payments/useConfirmPayment.ts
+++ b/src/hooks/payments/useConfirmPayment.ts
@@ -2,15 +2,15 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import type { ConfirmPaymentRequest } from '@/contracts/payment';
+import type { ConfirmPaymentInput } from '@/types/payment';
 import { invalidateTargets } from '@/lib/queryKeys';
 import { paymentApi } from '@/api/payments/paymentApi';
 
 export function useConfirmPayment() {
   const queryClient = useQueryClient();
 
-  return useMutation<void, Error, ConfirmPaymentRequest>({
-    mutationFn: (body) => paymentApi.confirmPayment(body),
+  return useMutation<void, Error, ConfirmPaymentInput>({
+    mutationFn: (input) => paymentApi.confirmPayment(input),
     onSuccess: () => {
       invalidateTargets.afterConfirmPayment.forEach((queryKey) => {
         void queryClient.invalidateQueries({ queryKey });

--- a/src/hooks/products/useProducts.ts
+++ b/src/hooks/products/useProducts.ts
@@ -5,8 +5,7 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import { useState } from 'react';
 
 import type { PaginatedResult } from '@/types/common';
-import type { Product } from '@/types/product';
-import type { ProductListParams } from '@/contracts/product';
+import type { Product, ProductListQuery } from '@/types/product';
 import { queryKeys } from '@/lib/queryKeys';
 import { productApi } from '@/api/products/productApi';
 
@@ -17,7 +16,7 @@ interface UseProductsOptions {
 const INITIAL_PRODUCT_LIST_STALE_TIME_MS = 30_000;
 
 export function useProducts(
-  params: ProductListParams,
+  params: ProductListQuery,
   options?: UseProductsOptions
 ): UseQueryResult<PaginatedResult<Product>> {
   const hasInitialData = Boolean(options?.initialData);

--- a/src/hooks/seller/applications/useCreateSellerApplication.ts
+++ b/src/hooks/seller/applications/useCreateSellerApplication.ts
@@ -3,33 +3,24 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type {
+  CreateSellerApplicationInput,
   SellerApplication,
+  SellerApplicationDocumentFiles,
+  SellerApplicationDocumentUploadInput,
   SellerApplicationDocumentType,
 } from '@/types/seller-application';
-import type { CreateSellerApplicationRequest } from '@/contracts/seller-application';
 import { queryKeys } from '@/lib/queryKeys';
 import { fileApi } from '@/api/files/fileApi';
 import { sellerApplicationApi } from '@/api/seller-applications/sellerApplicationApi';
 
-type DocumentFiles = {
-  businessLicense: File;
-  foodServicePermit: File;
-  bankAccount: File;
+const DOC_TYPE_MAP: Record<
+  keyof SellerApplicationDocumentFiles,
+  SellerApplicationDocumentType
+> = {
+  businessLicense: 'business_license',
+  foodServicePermit: 'food_service_permit',
+  bankAccount: 'bank_account',
 };
-
-export type CreateSellerApplicationInput = Omit<
-  CreateSellerApplicationRequest,
-  'documents'
-> & {
-  documents: DocumentFiles;
-};
-
-const DOC_TYPE_MAP: Record<keyof DocumentFiles, SellerApplicationDocumentType> =
-  {
-    businessLicense: 'business_license',
-    foodServicePermit: 'food_service_permit',
-    bankAccount: 'bank_account',
-  };
 
 async function cleanupPaths(paths: string[]): Promise<void> {
   if (paths.length === 0) return;
@@ -46,7 +37,7 @@ export function useCreateSellerApplication() {
   return useMutation<SellerApplication, Error, CreateSellerApplicationInput>({
     mutationFn: async ({ documents, ...rest }) => {
       const entries = Object.entries(documents) as [
-        keyof DocumentFiles,
+        keyof SellerApplicationDocumentFiles,
         File,
       ][];
 
@@ -69,13 +60,7 @@ export function useCreateSellerApplication() {
       );
 
       const uploadedPaths: string[] = [];
-      const uploadedDocs: {
-        type: SellerApplicationDocumentType;
-        storagePath: string;
-        originalFileName: string;
-        contentType: string;
-        size: number;
-      }[] = [];
+      const uploadedDocs: SellerApplicationDocumentUploadInput[] = [];
       const firstError = results.find((r) => r.status === 'rejected');
 
       for (const result of results) {

--- a/src/hooks/seller/menu-items/useCreateSellerMenuItem.ts
+++ b/src/hooks/seller/menu-items/useCreateSellerMenuItem.ts
@@ -2,16 +2,15 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import type { MenuItem } from '@/types/menu-item';
-import type { CreateMenuItemRequest } from '@/contracts/menu-item';
+import type { CreateMenuItemInput, MenuItem } from '@/types/menu-item';
 import { queryKeys } from '@/lib/queryKeys';
 import { sellerMenuItemApi } from '@/api/seller/menu-items/sellerMenuItemApi';
 
 export function useCreateSellerMenuItem() {
   const queryClient = useQueryClient();
 
-  return useMutation<MenuItem, Error, CreateMenuItemRequest>({
-    mutationFn: (body) => sellerMenuItemApi.createMenuItem(body),
+  return useMutation<MenuItem, Error, CreateMenuItemInput>({
+    mutationFn: (input) => sellerMenuItemApi.createMenuItem(input),
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: queryKeys.sellers.menuItems.all(),

--- a/src/hooks/seller/menu-items/useSellerMenuItems.ts
+++ b/src/hooks/seller/menu-items/useSellerMenuItems.ts
@@ -2,12 +2,11 @@
 
 import { useQuery } from '@tanstack/react-query';
 
-import type { MenuItem } from '@/types/menu-item';
-import type { SellerMenuItemListParams } from '@/contracts/menu-item';
+import type { MenuItem, SellerMenuItemListQuery } from '@/types/menu-item';
 import { queryKeys } from '@/lib/queryKeys';
 import { sellerMenuItemApi } from '@/api/seller/menu-items/sellerMenuItemApi';
 
-export function useSellerMenuItems(params?: SellerMenuItemListParams) {
+export function useSellerMenuItems(params?: SellerMenuItemListQuery) {
   return useQuery<MenuItem[]>({
     queryKey: queryKeys.sellers.menuItems.list(params ?? {}),
     queryFn: () => sellerMenuItemApi.getMenuItems(params),

--- a/src/hooks/seller/menu-items/useUpdateSellerMenuItem.ts
+++ b/src/hooks/seller/menu-items/useUpdateSellerMenuItem.ts
@@ -2,14 +2,13 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import type { MenuItem } from '@/types/menu-item';
-import type { UpdateMenuItemRequest } from '@/contracts/menu-item';
+import type { MenuItem, UpdateMenuItemInput } from '@/types/menu-item';
 import { queryKeys } from '@/lib/queryKeys';
 import { sellerMenuItemApi } from '@/api/seller/menu-items/sellerMenuItemApi';
 
 interface UpdateSellerMenuItemVariables {
   id: string;
-  body: UpdateMenuItemRequest;
+  body: UpdateMenuItemInput;
 }
 
 export function useUpdateSellerMenuItem() {

--- a/src/hooks/seller/orders/useSellerOrders.ts
+++ b/src/hooks/seller/orders/useSellerOrders.ts
@@ -3,12 +3,11 @@
 import { useQuery } from '@tanstack/react-query';
 
 import type { PaginatedResult } from '@/types/common';
-import type { Order } from '@/types/order';
-import type { SellerOrderListParams } from '@/contracts/order';
+import type { Order, SellerOrderListQuery } from '@/types/order';
 import { queryKeys } from '@/lib/queryKeys';
 import { sellerOrderApi } from '@/api/seller/orders/sellerOrderApi';
 
-export function useSellerOrders(params?: Partial<SellerOrderListParams>) {
+export function useSellerOrders(params?: Partial<SellerOrderListQuery>) {
   return useQuery<PaginatedResult<Omit<Order, 'items' | 'payment'>>>({
     queryKey: queryKeys.sellers.orders.list(params ?? {}),
     queryFn: () => sellerOrderApi.getOrders(params),

--- a/src/hooks/seller/products/useCreateSellerProduct.ts
+++ b/src/hooks/seller/products/useCreateSellerProduct.ts
@@ -3,22 +3,14 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type { CreateSellerProductInput, Product } from '@/types/product';
-import type { CreateSellerProductRequest } from '@/contracts/product';
 import { queryKeys } from '@/lib/queryKeys';
 import { sellerProductApi } from '@/api/seller/products/sellerProductApi';
-
-function toCreateSellerProductRequest(
-  input: CreateSellerProductInput
-): CreateSellerProductRequest {
-  return { ...input, endAt: input.endAt.toISOString() };
-}
 
 export function useCreateSellerProduct() {
   const queryClient = useQueryClient();
 
   return useMutation<Product, Error, CreateSellerProductInput>({
-    mutationFn: (input) =>
-      sellerProductApi.createProduct(toCreateSellerProductRequest(input)),
+    mutationFn: (input) => sellerProductApi.createProduct(input),
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: queryKeys.products.sellerList(),

--- a/src/hooks/seller/products/useUpdateSellerProduct.ts
+++ b/src/hooks/seller/products/useUpdateSellerProduct.ts
@@ -2,14 +2,13 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import type { Product } from '@/types/product';
-import type { UpdateSellerProductRequest } from '@/contracts/product';
+import type { Product, UpdateSellerProductInput } from '@/types/product';
 import { queryKeys } from '@/lib/queryKeys';
 import { sellerProductApi } from '@/api/seller/products/sellerProductApi';
 
 interface UpdateSellerProductVariables {
   id: string;
-  body: UpdateSellerProductRequest;
+  body: UpdateSellerProductInput;
 }
 
 export function useUpdateSellerProduct() {

--- a/src/hooks/stores/useCreateStore.ts
+++ b/src/hooks/stores/useCreateStore.ts
@@ -3,16 +3,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type { CreateStoreInput, MyStore } from '@/types/store';
-import type { CreateStoreRequest } from '@/contracts/store';
 import { queryKeys } from '@/lib/queryKeys';
 import { fileApi } from '@/api/files/fileApi';
 import { storeApi } from '@/api/stores/storeApi';
 
 type CreateStoreVariables = CreateStoreInput & { imageFile?: File };
-
-function toCreateStoreRequest(input: CreateStoreInput): CreateStoreRequest {
-  return { ...input };
-}
 
 export function useCreateStore() {
   const queryClient = useQueryClient();
@@ -21,9 +16,9 @@ export function useCreateStore() {
     mutationFn: async ({ imageFile, ...input }) => {
       if (imageFile) {
         const image = await fileApi.uploadFile('store_image', imageFile);
-        return storeApi.createStore(toCreateStoreRequest({ ...input, image }));
+        return storeApi.createStore({ ...input, image });
       }
-      return storeApi.createStore(toCreateStoreRequest(input));
+      return storeApi.createStore(input);
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.stores.my() });

--- a/src/hooks/stores/useUpdateStore.ts
+++ b/src/hooks/stores/useUpdateStore.ts
@@ -3,16 +3,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type { UpdateStoreInput, MyStore } from '@/types/store';
-import type { UpdateStoreRequest } from '@/contracts/store';
 import { queryKeys } from '@/lib/queryKeys';
 import { fileApi } from '@/api/files/fileApi';
 import { storeApi } from '@/api/stores/storeApi';
 
 type UpdateStoreVariables = UpdateStoreInput & { imageFile?: File };
-
-function toUpdateStoreRequest(input: UpdateStoreInput): UpdateStoreRequest {
-  return { ...input };
-}
 
 export function useUpdateStore() {
   const queryClient = useQueryClient();
@@ -21,9 +16,9 @@ export function useUpdateStore() {
     mutationFn: async ({ imageFile, ...input }) => {
       if (imageFile) {
         const image = await fileApi.uploadFile('store_image', imageFile);
-        return storeApi.updateStore(toUpdateStoreRequest({ ...input, image }));
+        return storeApi.updateStore({ ...input, image });
       }
-      return storeApi.updateStore(toUpdateStoreRequest(input));
+      return storeApi.updateStore(input);
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.stores.my() });

--- a/src/hooks/users/useUpdateMe.ts
+++ b/src/hooks/users/useUpdateMe.ts
@@ -2,13 +2,12 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import type { User } from '@/types/user';
-import type { UpdateMeRequest } from '@/contracts/user';
+import type { UpdateMeInput, User } from '@/types/user';
 import { queryKeys } from '@/lib/queryKeys';
 import { fileApi } from '@/api/files/fileApi';
 import { userApi } from '@/api/users/userApi';
 
-type UpdateMeVariables = UpdateMeRequest & { imageFile?: File };
+type UpdateMeVariables = UpdateMeInput & { imageFile?: File };
 
 export function useUpdateMe() {
   const queryClient = useQueryClient();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,27 +1,51 @@
 export type { AdminDashboardStats } from './admin';
 export type { AuthProvider, AuthResult, AuthSession, AuthUser } from './auth';
 export type {
+  CancelPaymentInput,
+  ConfirmPaymentInput,
+  Payment,
+  PaymentMethod,
+  PaymentStatus,
+  PreparePaymentInput,
+} from './payment';
+export type {
   ConsumerOrderListQuery,
   CreatedOrderPaymentInfo,
+  CreateOrderInput,
   Order,
   OrderItem,
   OrderStatus,
+  SellerOrderListQuery,
 } from './order';
-export type { MyStore, OperationStatus, Store, StoreStatus } from './store';
-export type { PaginatedResult, SortOrder } from './common';
-export type { Payment, PaymentMethod, PaymentStatus } from './payment';
 export type {
-  Product,
-  ProductDetail,
-  ProductDisplayStatus,
-  ProductStatus,
-} from './product';
+  CreateMenuItemInput,
+  MenuItem,
+  MenuItemStatus,
+  SellerMenuItemListQuery,
+  UpdateMenuItemInput,
+} from './menu-item';
 export type {
+  CreateSellerApplicationInput,
+  CreateSellerApplicationPayload,
   SellerApplication,
   SellerApplicationDocument,
+  SellerApplicationDocumentFiles,
   SellerApplicationDocumentType,
+  SellerApplicationDocumentUploadInput,
   SellerApplicationStatus,
   SellerApplicationStatusForOnboarding,
   SellerOnboardingStatus,
 } from './seller-application';
-export type { User, UserRole, UserStatus } from './user';
+export type {
+  CreateSellerProductInput,
+  Product,
+  ProductDetail,
+  ProductDiscountOption,
+  ProductDisplayStatus,
+  ProductListQuery,
+  ProductStatus,
+  UpdateSellerProductInput,
+} from './product';
+export type { MyStore, OperationStatus, Store, StoreStatus } from './store';
+export type { PaginatedResult, SortOrder } from './common';
+export type { UpdateMeInput, User, UserRole, UserStatus } from './user';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,6 +46,13 @@ export type {
   ProductStatus,
   UpdateSellerProductInput,
 } from './product';
-export type { MyStore, OperationStatus, Store, StoreStatus } from './store';
+export type {
+  CreateStoreInput,
+  MyStore,
+  OperationStatus,
+  Store,
+  StoreStatus,
+  UpdateStoreInput,
+} from './store';
 export type { PaginatedResult, SortOrder } from './common';
 export type { UpdateMeInput, User, UserRole, UserStatus } from './user';

--- a/src/types/menu-item.ts
+++ b/src/types/menu-item.ts
@@ -13,3 +13,26 @@ export interface MenuItem {
   createdAt: Date;
   updatedAt: Date;
 }
+
+export interface SellerMenuItemListQuery {
+  categoryId?: string;
+  keyword?: string;
+  status?: MenuItemStatus;
+}
+
+export interface CreateMenuItemInput {
+  categoryId: string;
+  name: string;
+  description?: string;
+  image?: string;
+  originalPrice: number;
+}
+
+export interface UpdateMenuItemInput {
+  categoryId?: string;
+  name?: string;
+  description?: string;
+  image?: string;
+  originalPrice?: number;
+  status?: MenuItemStatus;
+}

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -57,6 +57,20 @@ export interface ConsumerOrderListQuery {
   order: 'asc' | 'desc';
 }
 
+export interface SellerOrderListQuery {
+  page: number;
+  pageSize: number;
+  status?: Exclude<OrderStatus, 'paymentPending' | 'processing'>;
+  sort: 'createdAt' | 'pickupAt';
+  order: 'asc' | 'desc';
+}
+
+export interface CreateOrderInput {
+  productId: string;
+  quantity: number;
+  pickupAt: Date;
+}
+
 export interface CreatedOrderPaymentInfo {
   id: string;
   orderNumber: string;

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -21,3 +21,18 @@ export interface Payment {
   createdAt: Date;
   updatedAt: Date;
 }
+
+export interface PreparePaymentInput {
+  orderNumber: string;
+  orderName: string;
+}
+
+export interface ConfirmPaymentInput {
+  paymentKey: string;
+  orderNumber: string;
+  amount: number;
+}
+
+export interface CancelPaymentInput {
+  reason: string;
+}

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,6 +1,25 @@
+import type { ProductDiscountOption } from '@/contracts/product';
+
 import type { Store } from './store';
 
+export type { ProductDiscountOption } from '@/contracts/product';
+
 export type ProductStatus = 'active' | 'closed';
+
+export interface ProductListQuery {
+  page: number;
+  pageSize: number;
+  userLat?: number;
+  userLng?: number;
+  categoryId?: string;
+  keyword?: string;
+  minPrice?: number;
+  maxPrice?: number;
+  discountOption?: ProductDiscountOption;
+  sort?: 'endAt' | 'discountRate' | 'discountPrice' | 'distance';
+  order?: 'asc' | 'desc';
+  availableOnly?: boolean;
+}
 
 export interface CreateSellerProductInput {
   menuItemId: string;
@@ -9,6 +28,15 @@ export interface CreateSellerProductInput {
   endAt: Date;
   pickupStartTime: string;
   pickupEndTime: string;
+}
+
+export interface UpdateSellerProductInput {
+  discountPrice?: number;
+  stock?: number;
+  endAt?: Date;
+  pickupStartTime?: string;
+  pickupEndTime?: string;
+  status?: ProductStatus;
 }
 
 export type ProductDisplayStatus =

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,10 +1,13 @@
-import type { ProductDiscountOption } from '@/contracts/product';
-
 import type { Store } from './store';
 
-export type { ProductDiscountOption } from '@/contracts/product';
-
 export type ProductStatus = 'active' | 'closed';
+
+export type ProductDiscountOption =
+  | 'all'
+  | 'over-40'
+  | '30-to-40'
+  | '20-to-30'
+  | 'under-20';
 
 export interface ProductListQuery {
   page: number;

--- a/src/types/seller-application.ts
+++ b/src/types/seller-application.ts
@@ -37,6 +37,38 @@ export interface SellerApplication {
   updatedAt: Date;
 }
 
+export type SellerApplicationDocumentFiles = {
+  businessLicense: File;
+  foodServicePermit: File;
+  bankAccount: File;
+};
+
+export interface CreateSellerApplicationInput {
+  businessNumber: string;
+  companyName: string;
+  representativeName: string;
+  businessAddress: string;
+  businessType: string;
+  businessCategory: string;
+  documentConsentAgreed: boolean;
+  documents: SellerApplicationDocumentFiles;
+}
+
+export interface SellerApplicationDocumentUploadInput {
+  type: SellerApplicationDocumentType;
+  storagePath: string;
+  originalFileName: string;
+  contentType: string;
+  size: number;
+}
+
+export interface CreateSellerApplicationPayload extends Omit<
+  CreateSellerApplicationInput,
+  'documents'
+> {
+  documents: SellerApplicationDocumentUploadInput[];
+}
+
 export interface AdminPendingSellerApplication extends Omit<
   SellerApplication,
   | 'status'

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -16,3 +16,9 @@ export interface User {
   createdAt: Date;
   updatedAt: Date;
 }
+
+export interface UpdateMeInput {
+  name?: string;
+  phone?: string;
+  profileImage?: string;
+}


### PR DESCRIPTION
## 📌 작업 내용

- hook 외부 입력이 Contract request DTO에 직접 결합되지 않도록 Domain/UI 입력 타입으로 분리했습니다.
- API client wrapper에서 Domain/UI 입력을 Contract DTO로 변환하도록 책임 위치를 정리했습니다.
- Date 기반 입력은 API boundary에서 ISO string으로 변환하도록 고정했습니다.

Task ID: T25

## 🔧 변경 사항

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 문서 수정

## 📚 문서/Task 반영

- [x] 관련 `docs/*` 최신화 필요 여부 확인
- [x] 필요한 문서 수정 반영 또는 후속 task/확인 필요로 기록
- [x] `docs/tasks` 상태와 GitHub Issue 번호 갱신

## 📂 주요 변경 파일

- `src/types/order.ts`
- `src/types/payment.ts`
- `src/types/product.ts`
- `src/types/menu-item.ts`
- `src/types/seller-application.ts`
- `src/api/orders/orderApi.ts`
- `src/api/payments/paymentApi.ts`
- `src/api/seller/products/sellerProductApi.ts`
- `src/hooks/orders/useCreateOrder.ts`
- `src/hooks/payments/useConfirmPayment.ts`
- `src/hooks/products/useProducts.ts`
- `docs/tasks/T25_hook_input_domain_ui_type_split.md`
- `docs/tasks/README.md`

## 🧪 테스트 방법

- `npm run test -- src/api/orders/orderApi.test.ts src/api/seller/products/sellerProductApi.test.ts src/api/payments/paymentApi.test.ts src/api/stores/storeApi.test.ts src/hooks/products/useProducts.test.ts src/hooks/seller/orders/sellerOrders.test.ts src/hooks/seller/applications/useCreateSellerApplication.test.ts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

## 📸 스크린샷 (선택)

- UI 변경 없음

## 🔗 관련 이슈

- close #252 
