### PR TITLE
feat: 지도 UI/UX 개선

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -93,7 +93,7 @@ PickMa 심화 프로젝트 task의 공유 기준 문서다. `temp/`는 로컬 �
 | T65 | 도메인 컴포넌트 폴더 구조 통일                               | P1       | 완료    | 253          | T64                          | [T65_domain_component_folder_unification.md](T65_domain_component_folder_unification.md)                         |
 | T66 | 모바일 앱 래핑 (Capacitor / PWA)                             | P3       | 진행 전 | 확인 필요    | T45                          | [T66_mobile_app_capacitor_pwa.md](T66_mobile_app_capacitor_pwa.md)                                               |
 | T67 | i18n 기본 설정 (next-intl, 한국어)                           | P2       | 진행 전 | 확인 필요    | T45                          | [T67_i18n_setup.md](T67_i18n_setup.md)                                                                           |
-| T68 | 지도 UI/UX 개선                                              | P2       | 진행 전 | 확인 필요    | T21                          | [T68_map_ui_ux_improvement.md](T68_map_ui_ux_improvement.md)                                                     |
+| T68 | 지도 UI/UX 개선                                              | P2       | 완료    | 266          | T21                          | [T68_map_ui_ux_improvement.md](T68_map_ui_ux_improvement.md)                                                     |
 | T69 | 소비자 위치/검색 기능 확장                                   | P3       | 진행 전 | 확인 필요    | T21                          | [T69_consumer_location_search_extension.md](T69_consumer_location_search_extension.md)                           |
 
 ## 추천 진행 흐름

--- a/docs/tasks/T68_map_ui_ux_improvement.md
+++ b/docs/tasks/T68_map_ui_ux_improvement.md
@@ -34,15 +34,19 @@
   - FAB 위치가 불편하다 판단될 경우 섹션 버튼 등으로 전환이 필요하다.
   - 지도에서 상품 확인 후 예약하려면 메인으로 돌아가 가게를 다시 검색해야 해서 흐름이 끊긴다.
   - 지도 이동 시 목록 재조회로 인해 사이드바/하단 시트가 깜빡이는 현상이 발생한다.
+  - location 변경 시 이전 mapOffset이 유지되어 새 위치가 아닌 직전 지도 중심으로 상품이 조회된다.
+  - 클러스터러에 마커를 추가하기 전 map에 먼저 붙어 렌더링/제어 책임이 섞인다.
 
 - 작업 내용:
-  - 하단 시트를 반응형으로 전환한다: 모바일은 현행 유지(하단 슬라이드), 데스크탑(`md+`)은 우측 사이드바로 표시.
+  - 하단 시트를 반응형으로 전환한다: 모바일은 현행 유지(하단 슬라이드), 데스크탑(`md+`)은 좌측 사이드바로 표시.
   - 지도 드래그/줌 종료 시 현재 지도 중심 좌표로 목록을 재조회한다.
   - Kakao Maps MarkerClusterer를 적용해 줌 레벨에 따라 겹치는 핀을 클러스터링한다.
-  - FAB 사용성 피드백에 따라 위치 또는 진입 방식을 조정한다.
-  - 사이드바/하단 시트 상품 아이템을 상품 상세(`/products/:id`)로 이동하는 링크로 전환한다.
+  - 사이드바/하단 시트 상품 아이템을 상품 상세(`/products/[productId]`)로 이동하는 링크로 전환한다.
   - 상품 아이템에 픽업 시간 정보를 추가한다.
   - 지도 이동 중 사이드바/하단 시트 깜빡임 방지를 위해 `useProducts`에 `keepPrevious` 옵션을 추가한다.
+  - location 변경 시 `mapOffset`을 즉시 초기화해 새 위치 기준으로 상품을 조회한다.
+  - `createKakaoMarker`에서 map 인자를 제거해 클러스터러가 마커 소유/연결을 담당하도록 한다.
+  - 모바일/데스크탑 패널 공통 로직을 `StorePanel` 컴포넌트로 추출한다.
 
 - 관련 파일/영역:
   - `src/components/consumer/StoreProductBottomSheet.tsx`
@@ -57,16 +61,19 @@
   중간
 
 - 완료 기준:
-  - 데스크탑에서 핀 클릭 시 우측 사이드바로 표시된다.
+  - 데스크탑에서 핀 클릭 시 좌측 사이드바로 표시된다.
   - 지도 영역 이동 후 목록이 현재 중심 기준으로 갱신된다.
   - 밀집 영역에서 핀 클러스터링이 동작한다.
-  - 사이드바/하단 시트 상품 클릭 시 상품 상세 페이지로 이동한다.
+  - 사이드바/하단 시트 상품 클릭 시 상품 상세 페이지(`/products/[productId]`)로 이동한다.
   - 지도 이동 중 사이드바/하단 시트가 깜빡이지 않는다.
+  - location 변경 시 새 위치 기준으로 상품이 즉시 재조회된다.
+  - 클러스터러가 마커 소유/연결을 단독으로 담당한다.
 
 - 구현 결과:
-  - 반응형 레이아웃: 모바일(`md` 미만)은 하단 슬라이드 시트, 데스크탑(`md+`)은 우측 고정 사이드바(`w-80`)로 분기 처리했다.
-  - 지도 중심 재조회: Kakao Maps `idle` 이벤트로 드래그/줌 종료를 감지해 `onCenterChange` 콜백으로 중심 좌표를 상위로 전달하고, `MapPageClient`의 `mapCenter` state 갱신으로 `useProducts` 재조회를 트리거한다.
-  - 핀 클러스터링: `src/lib/kakao/map.ts`에 `KakaoMarkerClustererInstance` 타입과 `createMarkerClusterer` 유틸을 추가하고, SDK URL에 `clusterer` 라이브러리를 포함했다. 줌 레벨 6 이상에서 인접 핀이 클러스터로 묶인다.
-  - 상품 상세 진입: 상품 아이템을 `<Link href="/products/:id">`로 감싸 지도에서 바로 상품 상세로 이동할 수 있도록 했다. 픽업 시간 정보도 함께 노출한다.
-  - FAB 위치: `bottom-6` → `bottom-24`로 조정해 모바일 하단 네비게이션과의 겹침을 방지했다.
+  - 반응형 레이아웃: 모바일(`md` 미만)은 하단 슬라이드 시트, 데스크탑(`md+`)은 좌측 고정 사이드바(`w-80`)로 분기 처리했다. 공통 헤더/컨텐츠 로직은 `StorePanel` 컴포넌트로 추출해 중복을 제거했다.
+  - 지도 중심 재조회: Kakao Maps `idle` 이벤트로 드래그/줌 종료를 감지해 `onCenterChange` 콜백으로 중심 좌표를 상위로 전달하고, `MapPageClient`의 `mapOffset` state 갱신으로 `useProducts` 재조회를 트리거한다.
+  - location 동기화: location 변경 시 `handleLocationChange`에서 `setMapOffset(null)`을 즉시 호출해 이전 지도 중심으로 조회되는 문제를 해결했다. 또한 `key={locationKey}`로 `StoreMapView`를 리마운트해 지도 상태도 초기화한다.
+  - 핀 클러스터링: `src/lib/kakao/map.ts`에 `KakaoMarkerClustererInstance` 타입과 `createMarkerClusterer` 유틸을 추가하고, SDK URL에 `clusterer` 라이브러리를 포함했다. `createKakaoMarker`에서 map 인자를 제거해 클러스터러가 마커 소유/연결을 단독으로 담당한다. 줌 레벨 6 이상에서 인접 핀이 클러스터로 묶인다. cleanup 시 idle 리스너 제거, 마커 detach, clusterer clear를 수행해 메모리 누수를 방지한다.
+  - 상품 상세 진입: 상품 아이템을 `<Link href={`/products/${product.id}`}>`로 감싸 지도에서 바로 상품 상세(`/products/[productId]`)로 이동할 수 있도록 했다. 픽업 시간 정보도 함께 노출한다.
+  - FAB 위치: dev 전용 Mock User 네비게이션을 기준으로 위치를 조정하면 production 환경에서 어색해지므로 `bottom-6` 원래 위치를 유지했다.
   - 깜빡임 방지: `useProducts`에 `keepPrevious` 옵션을 추가해 지도 이동 중 새 쿼리 로딩 시 이전 데이터를 유지하도록 했다. `MapPageClient`에서 `keepPrevious: true`로 사용한다.

--- a/docs/tasks/T68_map_ui_ux_improvement.md
+++ b/docs/tasks/T68_map_ui_ux_improvement.md
@@ -1,10 +1,10 @@
 # T68. 지도 UI/UX 개선
 
 - 상태:
-  진행 전
+  완료
 
 - GitHub Issue:
-  확인 필요
+  266
 
 - 우선순위:
   P2
@@ -32,18 +32,26 @@
   - 지도 영역을 이동해도 목록이 갱신되지 않는다.
   - 가게가 밀집된 영역에서 핀이 겹쳐 클릭이 어렵다.
   - FAB 위치가 불편하다 판단될 경우 섹션 버튼 등으로 전환이 필요하다.
+  - 지도에서 상품 확인 후 예약하려면 메인으로 돌아가 가게를 다시 검색해야 해서 흐름이 끊긴다.
+  - 지도 이동 시 목록 재조회로 인해 사이드바/하단 시트가 깜빡이는 현상이 발생한다.
 
 - 작업 내용:
   - 하단 시트를 반응형으로 전환한다: 모바일은 현행 유지(하단 슬라이드), 데스크탑(`md+`)은 우측 사이드바로 표시.
   - 지도 드래그/줌 종료 시 현재 지도 중심 좌표로 목록을 재조회한다.
   - Kakao Maps MarkerClusterer를 적용해 줌 레벨에 따라 겹치는 핀을 클러스터링한다.
   - FAB 사용성 피드백에 따라 위치 또는 진입 방식을 조정한다.
+  - 사이드바/하단 시트 상품 아이템을 상품 상세(`/products/:id`)로 이동하는 링크로 전환한다.
+  - 상품 아이템에 픽업 시간 정보를 추가한다.
+  - 지도 이동 중 사이드바/하단 시트 깜빡임 방지를 위해 `useProducts`에 `keepPrevious` 옵션을 추가한다.
 
 - 관련 파일/영역:
   - `src/components/consumer/StoreProductBottomSheet.tsx`
   - `src/components/consumer/StoreMapView.tsx`
   - `src/components/consumer/MapPageClient.tsx`
   - `src/components/consumer/MapViewFab.tsx`
+  - `src/lib/kakao/map.ts`
+  - `src/lib/kakao/sdk.ts`
+  - `src/hooks/products/useProducts.ts`
 
 - 예상 난이도:
   중간
@@ -52,3 +60,13 @@
   - 데스크탑에서 핀 클릭 시 우측 사이드바로 표시된다.
   - 지도 영역 이동 후 목록이 현재 중심 기준으로 갱신된다.
   - 밀집 영역에서 핀 클러스터링이 동작한다.
+  - 사이드바/하단 시트 상품 클릭 시 상품 상세 페이지로 이동한다.
+  - 지도 이동 중 사이드바/하단 시트가 깜빡이지 않는다.
+
+- 구현 결과:
+  - 반응형 레이아웃: 모바일(`md` 미만)은 하단 슬라이드 시트, 데스크탑(`md+`)은 우측 고정 사이드바(`w-80`)로 분기 처리했다.
+  - 지도 중심 재조회: Kakao Maps `idle` 이벤트로 드래그/줌 종료를 감지해 `onCenterChange` 콜백으로 중심 좌표를 상위로 전달하고, `MapPageClient`의 `mapCenter` state 갱신으로 `useProducts` 재조회를 트리거한다.
+  - 핀 클러스터링: `src/lib/kakao/map.ts`에 `KakaoMarkerClustererInstance` 타입과 `createMarkerClusterer` 유틸을 추가하고, SDK URL에 `clusterer` 라이브러리를 포함했다. 줌 레벨 6 이상에서 인접 핀이 클러스터로 묶인다.
+  - 상품 상세 진입: 상품 아이템을 `<Link href="/products/:id">`로 감싸 지도에서 바로 상품 상세로 이동할 수 있도록 했다. 픽업 시간 정보도 함께 노출한다.
+  - FAB 위치: `bottom-6` → `bottom-24`로 조정해 모바일 하단 네비게이션과의 겹침을 방지했다.
+  - 깜빡임 방지: `useProducts`에 `keepPrevious` 옵션을 추가해 지도 이동 중 새 쿼리 로딩 시 이전 데이터를 유지하도록 했다. `MapPageClient`에서 `keepPrevious: true`로 사용한다.

--- a/src/components/consumer/MapPageClient.tsx
+++ b/src/components/consumer/MapPageClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useUserLocation } from '@/hooks/consumer/useUserLocation';
 import { useProducts } from '@/hooks/products/useProducts';
@@ -26,6 +26,10 @@ const MAP_PRODUCT_PAGE_SIZE = 50;
 export function MapPageClient() {
   const { location, saveLocation } = useUserLocation();
   const geoAttempted = useRef(false);
+  const [mapCenter, setMapCenter] = useState<{
+    lat: number;
+    lng: number;
+  } | null>(null);
 
   useEffect(() => {
     if (location || geoAttempted.current || !navigator.geolocation) return;
@@ -45,25 +49,39 @@ export function MapPageClient() {
     );
   }, [location, saveLocation]);
 
+  const queryLat = mapCenter?.lat ?? location?.lat;
+  const queryLng = mapCenter?.lng ?? location?.lng;
+
   const { data: productList } = useProducts(
     {
       sort: 'distance',
-      userLat: location?.lat,
-      userLng: location?.lng,
+      userLat: queryLat,
+      userLng: queryLng,
       page: 1,
       pageSize: MAP_PRODUCT_PAGE_SIZE,
     },
-    { enabled: !!location }
+    {
+      enabled: !!location,
+      keepPrevious: true,
+    }
   );
 
   const products = productList?.items ?? [];
+
+  const handleCenterChange = useCallback((lat: number, lng: number) => {
+    setMapCenter({ lat, lng });
+  }, []);
 
   return (
     <div className="flex h-dvh flex-col">
       <ConsumerMapHeader location={location} onLocationChange={saveLocation} />
       <main className="min-h-0 flex-1">
         {location ? (
-          <StoreMapView location={location} products={products} />
+          <StoreMapView
+            location={location}
+            products={products}
+            onCenterChange={handleCenterChange}
+          />
         ) : (
           <div className="flex h-full items-center justify-center p-6">
             <NoLocationView onLocationChange={saveLocation} />

--- a/src/components/consumer/MapPageClient.tsx
+++ b/src/components/consumer/MapPageClient.tsx
@@ -26,7 +26,7 @@ const MAP_PRODUCT_PAGE_SIZE = 50;
 export function MapPageClient() {
   const { location, saveLocation } = useUserLocation();
   const geoAttempted = useRef(false);
-  const [mapCenter, setMapCenter] = useState<{
+  const [mapOffset, setMapOffset] = useState<{
     lat: number;
     lng: number;
   } | null>(null);
@@ -49,8 +49,8 @@ export function MapPageClient() {
     );
   }, [location, saveLocation]);
 
-  const queryLat = mapCenter?.lat ?? location?.lat;
-  const queryLng = mapCenter?.lng ?? location?.lng;
+  const queryLat = mapOffset?.lat ?? location?.lat;
+  const queryLng = mapOffset?.lng ?? location?.lng;
 
   const { data: productList } = useProducts(
     {
@@ -69,8 +69,10 @@ export function MapPageClient() {
   const products = productList?.items ?? [];
 
   const handleCenterChange = useCallback((lat: number, lng: number) => {
-    setMapCenter({ lat, lng });
+    setMapOffset({ lat, lng });
   }, []);
+
+  const locationKey = location ? `${location.lat},${location.lng}` : 'none';
 
   return (
     <div className="flex h-dvh flex-col">
@@ -78,6 +80,7 @@ export function MapPageClient() {
       <main className="min-h-0 flex-1">
         {location ? (
           <StoreMapView
+            key={locationKey}
             location={location}
             products={products}
             onCenterChange={handleCenterChange}

--- a/src/components/consumer/MapPageClient.tsx
+++ b/src/components/consumer/MapPageClient.tsx
@@ -3,6 +3,7 @@
 import dynamic from 'next/dynamic';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import type { UserLocation } from '@/hooks/consumer/useUserLocation';
 import { useUserLocation } from '@/hooks/consumer/useUserLocation';
 import { useProducts } from '@/hooks/products/useProducts';
 
@@ -49,6 +50,14 @@ export function MapPageClient() {
     );
   }, [location, saveLocation]);
 
+  const handleLocationChange = useCallback(
+    (newLocation: Omit<UserLocation, 'savedAt'>) => {
+      setMapOffset(null);
+      saveLocation(newLocation);
+    },
+    [saveLocation]
+  );
+
   const queryLat = mapOffset?.lat ?? location?.lat;
   const queryLng = mapOffset?.lng ?? location?.lng;
 
@@ -76,7 +85,10 @@ export function MapPageClient() {
 
   return (
     <div className="flex h-dvh flex-col">
-      <ConsumerMapHeader location={location} onLocationChange={saveLocation} />
+      <ConsumerMapHeader
+        location={location}
+        onLocationChange={handleLocationChange}
+      />
       <main className="min-h-0 flex-1">
         {location ? (
           <StoreMapView
@@ -87,7 +99,7 @@ export function MapPageClient() {
           />
         ) : (
           <div className="flex h-full items-center justify-center p-6">
-            <NoLocationView onLocationChange={saveLocation} />
+            <NoLocationView onLocationChange={handleLocationChange} />
           </div>
         )}
       </main>

--- a/src/components/consumer/MapViewFab.tsx
+++ b/src/components/consumer/MapViewFab.tsx
@@ -7,7 +7,7 @@ export function MapViewFab() {
   return (
     <Link
       href="/map"
-      className="bg-primary-500 hover:bg-primary-600 fixed right-6 bottom-24 z-40 flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-colors"
+      className="bg-primary-500 hover:bg-primary-600 fixed right-6 bottom-6 z-40 flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-colors"
       aria-label="지도 보기"
     >
       <MapIcon className="h-6 w-6 text-white" aria-hidden="true" />

--- a/src/components/consumer/MapViewFab.tsx
+++ b/src/components/consumer/MapViewFab.tsx
@@ -7,7 +7,7 @@ export function MapViewFab() {
   return (
     <Link
       href="/map"
-      className="bg-primary-500 hover:bg-primary-600 fixed right-6 bottom-6 z-40 flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-colors"
+      className="bg-primary-500 hover:bg-primary-600 fixed right-6 bottom-24 z-40 flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-colors"
       aria-label="지도 보기"
     >
       <MapIcon className="h-6 w-6 text-white" aria-hidden="true" />

--- a/src/components/consumer/StoreMapView.tsx
+++ b/src/components/consumer/StoreMapView.tsx
@@ -109,7 +109,8 @@ export function StoreMapView({
     const newMarkers: KakaoMarkerInstance[] = [];
 
     for (const [storeId, { storeLat, storeLng }] of storeMap.entries()) {
-      const marker = createKakaoMarker(mapRef.current, storeLat, storeLng);
+      // map 인자 제거 → 클러스터러가 마커 소유/연결 담당
+      const marker = createKakaoMarker(storeLat, storeLng);
       const capturedId = storeId;
       maps.event.addListener(marker, 'click', () => {
         setSelectedStoreId(capturedId);

--- a/src/components/consumer/StoreMapView.tsx
+++ b/src/components/consumer/StoreMapView.tsx
@@ -51,21 +51,25 @@ export function StoreMapView({
   useEffect(() => {
     if (!containerRef.current) return;
     let mounted = true;
+    let handleIdle: (() => void) | null = null;
+    let map: KakaoMapInstance | null = null;
 
     setMapReady(false);
     setMapError(false);
+
     void loadKakaoMapsSDK()
       .then(() => {
         if (!mounted || !containerRef.current) return;
-        const map = initKakaoMap(containerRef.current, {
+
+        map = initKakaoMap(containerRef.current, {
           lat: location.lat,
           lng: location.lng,
         });
         mapRef.current = map;
 
         const maps = getKakaoMaps();
-        const handleIdle = () => {
-          const center = map.getCenter();
+        handleIdle = () => {
+          const center = map!.getCenter();
           onCenterChangeRef.current?.(center.getLat(), center.getLng());
         };
         maps.event.addListener(map, 'idle', handleIdle);
@@ -79,6 +83,26 @@ export function StoreMapView({
 
     return () => {
       mounted = false;
+
+      // idle 리스너 제거
+      if (map && handleIdle) {
+        const maps = getKakaoMaps();
+        maps.event.removeListener(map, 'idle', handleIdle);
+      }
+
+      // 마커 detach
+      for (const { marker } of markersRef.current) {
+        marker.setMap(null);
+      }
+      markersRef.current = [];
+
+      // 클러스터러 clear
+      if (clustererRef.current) {
+        clustererRef.current.clear();
+        clustererRef.current = null;
+      }
+
+      mapRef.current = null;
     };
   }, [location.lat, location.lng]);
 
@@ -109,7 +133,6 @@ export function StoreMapView({
     const newMarkers: KakaoMarkerInstance[] = [];
 
     for (const [storeId, { storeLat, storeLng }] of storeMap.entries()) {
-      // map 인자 제거 → 클러스터러가 마커 소유/연결 담당
       const marker = createKakaoMarker(storeLat, storeLng);
       const capturedId = storeId;
       maps.event.addListener(marker, 'click', () => {

--- a/src/components/consumer/StoreMapView.tsx
+++ b/src/components/consumer/StoreMapView.tsx
@@ -52,7 +52,7 @@ export function StoreMapView({
     if (!containerRef.current) return;
     let mounted = true;
     let handleIdle: (() => void) | null = null;
-    let map: KakaoMapInstance | null = null;
+    let mapInstance: KakaoMapInstance | null = null;
 
     setMapReady(false);
     setMapError(false);
@@ -61,20 +61,22 @@ export function StoreMapView({
       .then(() => {
         if (!mounted || !containerRef.current) return;
 
-        map = initKakaoMap(containerRef.current, {
+        mapInstance = initKakaoMap(containerRef.current, {
           lat: location.lat,
           lng: location.lng,
         });
-        mapRef.current = map;
+        mapRef.current = mapInstance;
 
         const maps = getKakaoMaps();
+
+        const capturedMap = mapInstance;
         handleIdle = () => {
-          const center = map!.getCenter();
+          const center = capturedMap.getCenter();
           onCenterChangeRef.current?.(center.getLat(), center.getLng());
         };
-        maps.event.addListener(map, 'idle', handleIdle);
+        maps.event.addListener(capturedMap, 'idle', handleIdle);
 
-        clustererRef.current = createMarkerClusterer(map);
+        clustererRef.current = createMarkerClusterer(capturedMap);
         setMapReady(true);
       })
       .catch(() => {
@@ -84,19 +86,20 @@ export function StoreMapView({
     return () => {
       mounted = false;
 
-      // idle 리스너 제거
-      if (map && handleIdle) {
-        const maps = getKakaoMaps();
-        maps.event.removeListener(map, 'idle', handleIdle);
+      if (mapInstance && handleIdle) {
+        try {
+          const maps = getKakaoMaps();
+          maps.event.removeListener(mapInstance, 'idle', handleIdle);
+        } catch {
+          // SDK 언로드 상태에서 removeListener 실패 시 무시
+        }
       }
 
-      // 마커 detach
       for (const { marker } of markersRef.current) {
         marker.setMap(null);
       }
       markersRef.current = [];
 
-      // 클러스터러 clear
       if (clustererRef.current) {
         clustererRef.current.clear();
         clustererRef.current = null;

--- a/src/components/consumer/StoreMapView.tsx
+++ b/src/components/consumer/StoreMapView.tsx
@@ -5,11 +5,16 @@ import { useEffect, useRef, useState } from 'react';
 import type { Product } from '@/types/product';
 import {
   createKakaoMarker,
+  createMarkerClusterer,
   getKakaoMaps,
   initKakaoMap,
   loadKakaoMapsSDK,
 } from '@/lib/kakao/map';
-import type { KakaoMapInstance, KakaoMarkerInstance } from '@/lib/kakao/map';
+import type {
+  KakaoMapInstance,
+  KakaoMarkerClustererInstance,
+  KakaoMarkerInstance,
+} from '@/lib/kakao/map';
 import type { UserLocation } from '@/hooks/consumer/useUserLocation';
 
 import { StoreProductBottomSheet } from './StoreProductBottomSheet';
@@ -22,15 +27,26 @@ interface StoreMarker {
 interface StoreMapViewProps {
   location: UserLocation;
   products: Product[];
+  onCenterChange?: (lat: number, lng: number) => void;
 }
 
-export function StoreMapView({ location, products }: StoreMapViewProps) {
+export function StoreMapView({
+  location,
+  products,
+  onCenterChange,
+}: StoreMapViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<KakaoMapInstance | null>(null);
   const markersRef = useRef<StoreMarker[]>([]);
+  const clustererRef = useRef<KakaoMarkerClustererInstance | null>(null);
+  const onCenterChangeRef = useRef(onCenterChange);
   const [mapReady, setMapReady] = useState(false);
   const [mapError, setMapError] = useState(false);
   const [selectedStoreId, setSelectedStoreId] = useState<string | null>(null);
+
+  useEffect(() => {
+    onCenterChangeRef.current = onCenterChange;
+  }, [onCenterChange]);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -41,10 +57,20 @@ export function StoreMapView({ location, products }: StoreMapViewProps) {
     void loadKakaoMapsSDK()
       .then(() => {
         if (!mounted || !containerRef.current) return;
-        mapRef.current = initKakaoMap(containerRef.current, {
+        const map = initKakaoMap(containerRef.current, {
           lat: location.lat,
           lng: location.lng,
         });
+        mapRef.current = map;
+
+        const maps = getKakaoMaps();
+        const handleIdle = () => {
+          const center = map.getCenter();
+          onCenterChangeRef.current?.(center.getLat(), center.getLng());
+        };
+        maps.event.addListener(map, 'idle', handleIdle);
+
+        clustererRef.current = createMarkerClusterer(map);
         setMapReady(true);
       })
       .catch(() => {
@@ -57,12 +83,13 @@ export function StoreMapView({ location, products }: StoreMapViewProps) {
   }, [location.lat, location.lng]);
 
   useEffect(() => {
-    if (!mapReady || !mapRef.current) return;
+    if (!mapReady || !mapRef.current || !clustererRef.current) return;
 
     for (const { marker } of markersRef.current) {
       marker.setMap(null);
     }
     markersRef.current = [];
+    clustererRef.current.clear();
 
     const storeMap = new Map<string, { storeLat: number; storeLng: number }>();
     for (const product of products) {
@@ -79,6 +106,8 @@ export function StoreMapView({ location, products }: StoreMapViewProps) {
     }
 
     const maps = getKakaoMaps();
+    const newMarkers: KakaoMarkerInstance[] = [];
+
     for (const [storeId, { storeLat, storeLng }] of storeMap.entries()) {
       const marker = createKakaoMarker(mapRef.current, storeLat, storeLng);
       const capturedId = storeId;
@@ -86,7 +115,10 @@ export function StoreMapView({ location, products }: StoreMapViewProps) {
         setSelectedStoreId(capturedId);
       });
       markersRef.current.push({ storeId, marker });
+      newMarkers.push(marker);
     }
+
+    clustererRef.current.addMarkers(newMarkers);
   }, [mapReady, products]);
 
   const validSelectedStoreId =

--- a/src/components/consumer/StoreProductBottomSheet.tsx
+++ b/src/components/consumer/StoreProductBottomSheet.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { XIcon } from 'lucide-react';
+import Link from 'next/link';
 
 import type { Product } from '@/types/product';
 import { Button } from '@/components/common';
@@ -21,50 +22,91 @@ export function StoreProductBottomSheet({
   const storeName = products[0]?.storeName;
 
   return (
-    <div className="absolute inset-x-0 bottom-0 z-30 rounded-t-2xl bg-white shadow-2xl">
-      <div className="flex items-center justify-between border-b border-gray-100 px-4 py-4">
-        <h2 className="text-base font-semibold text-gray-900">
-          {storeName ?? '가게 정보'}
-        </h2>
-        <Button
-          type="button"
-          variant="ghost"
-          color="gray"
-          className="p-1"
-          onClick={onClose}
-          aria-label="닫기"
-        >
-          <XIcon className="h-5 w-5" />
-        </Button>
+    <>
+      {/* 모바일: 하단 시트 */}
+      <div className="absolute inset-x-0 bottom-0 z-30 rounded-t-2xl bg-white shadow-2xl md:hidden">
+        <div className="flex items-center justify-between border-b border-gray-100 px-4 py-4">
+          <h2 className="text-base font-semibold text-gray-900">
+            {storeName ?? '가게 정보'}
+          </h2>
+          <Button
+            type="button"
+            variant="ghost"
+            color="gray"
+            className="p-1"
+            onClick={onClose}
+            aria-label="닫기"
+          >
+            <XIcon className="h-5 w-5" />
+          </Button>
+        </div>
+        <div className="max-h-72 overflow-y-auto px-4 py-3">
+          <ProductList products={products} />
+        </div>
       </div>
-      <div className="max-h-72 overflow-y-auto px-4 py-3">
-        {products.length === 0 ? (
-          <p className="py-6 text-center text-sm text-gray-500">
-            현재 판매 중인 상품이 없습니다
-          </p>
-        ) : (
-          <ul className="divide-y divide-gray-100">
-            {products.map((product) => (
-              <li key={product.id} className="flex items-center gap-3 py-3">
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium text-gray-900">
-                    {product.name}
-                  </p>
-                  <p className="mt-0.5 text-xs text-gray-500">
-                    {product.discountPrice.toLocaleString()}원{' '}
-                    <span className="font-medium text-red-500">
-                      {product.discountRate}%
-                    </span>
-                  </p>
-                </div>
-                <span className="shrink-0 text-xs text-gray-400">
-                  잔여 {product.availableStock}개
+
+      {/* 데스크탑: 우측 사이드바 */}
+      <div className="absolute inset-y-0 right-0 z-30 hidden w-80 flex-col bg-white shadow-2xl md:flex">
+        <div className="flex items-center justify-between border-b border-gray-100 px-4 py-4">
+          <h2 className="text-base font-semibold text-gray-900">
+            {storeName ?? '가게 정보'}
+          </h2>
+          <Button
+            type="button"
+            variant="ghost"
+            color="gray"
+            className="p-1"
+            onClick={onClose}
+            aria-label="닫기"
+          >
+            <XIcon className="h-5 w-5" />
+          </Button>
+        </div>
+        <div className="flex-1 overflow-y-auto px-4 py-3">
+          <ProductList products={products} />
+        </div>
+      </div>
+    </>
+  );
+}
+
+function ProductList({ products }: { products: Product[] }) {
+  if (products.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-gray-500">
+        현재 판매 중인 상품이 없습니다
+      </p>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-gray-100">
+      {products.map((product) => (
+        <li key={product.id}>
+          <Link
+            href={`/products/${product.id}`}
+            className="flex items-center gap-3 py-3 transition-colors hover:bg-gray-50"
+          >
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium text-gray-900">
+                {product.name}
+              </p>
+              <p className="mt-0.5 text-xs text-gray-500">
+                {product.discountPrice.toLocaleString()}원{' '}
+                <span className="font-medium text-red-500">
+                  {product.discountRate}%
                 </span>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-    </div>
+              </p>
+              <p className="mt-0.5 text-xs text-gray-400">
+                픽업 {product.pickupStartTime} ~ {product.pickupEndTime}
+              </p>
+            </div>
+            <span className="shrink-0 text-xs text-gray-400">
+              잔여 {product.availableStock}개
+            </span>
+          </Link>
+        </li>
+      ))}
+    </ul>
   );
 }

--- a/src/components/consumer/StoreProductBottomSheet.tsx
+++ b/src/components/consumer/StoreProductBottomSheet.tsx
@@ -70,12 +70,12 @@ export function StoreProductBottomSheet({
         containerClass="absolute inset-x-0 bottom-0 z-30 rounded-t-2xl bg-white shadow-2xl md:hidden"
         contentClass="max-h-72 overflow-y-auto px-4 py-3"
       />
-      {/* 데스크탑: 우측 사이드바 */}
+      {/* 데스크탑: 좌측 사이드바 */}
       <StorePanel
         storeName={storeName}
         products={products}
         onClose={onClose}
-        containerClass="absolute inset-y-0 right-0 z-30 hidden w-80 flex-col bg-white shadow-2xl md:flex"
+        containerClass="absolute inset-y-0 left-0 z-30 hidden w-80 flex-col bg-white shadow-2xl md:flex"
         contentClass="flex-1 overflow-y-auto px-4 py-3"
       />
     </>

--- a/src/components/consumer/StoreProductBottomSheet.tsx
+++ b/src/components/consumer/StoreProductBottomSheet.tsx
@@ -12,6 +12,45 @@ interface StoreProductBottomSheetProps {
   onClose: () => void;
 }
 
+interface StorePanelProps {
+  storeName: string | undefined;
+  products: Product[];
+  onClose: () => void;
+  containerClass: string;
+  contentClass: string;
+}
+
+function StorePanel({
+  storeName,
+  products,
+  onClose,
+  containerClass,
+  contentClass,
+}: StorePanelProps) {
+  return (
+    <div className={containerClass}>
+      <div className="flex items-center justify-between border-b border-gray-100 px-4 py-4">
+        <h2 className="text-base font-semibold text-gray-900">
+          {storeName ?? '가게 정보'}
+        </h2>
+        <Button
+          type="button"
+          variant="ghost"
+          color="gray"
+          className="p-1"
+          onClick={onClose}
+          aria-label="닫기"
+        >
+          <XIcon className="h-5 w-5" />
+        </Button>
+      </div>
+      <div className={contentClass}>
+        <ProductList products={products} />
+      </div>
+    </div>
+  );
+}
+
 export function StoreProductBottomSheet({
   storeId,
   products,
@@ -24,48 +63,21 @@ export function StoreProductBottomSheet({
   return (
     <>
       {/* 모바일: 하단 시트 */}
-      <div className="absolute inset-x-0 bottom-0 z-30 rounded-t-2xl bg-white shadow-2xl md:hidden">
-        <div className="flex items-center justify-between border-b border-gray-100 px-4 py-4">
-          <h2 className="text-base font-semibold text-gray-900">
-            {storeName ?? '가게 정보'}
-          </h2>
-          <Button
-            type="button"
-            variant="ghost"
-            color="gray"
-            className="p-1"
-            onClick={onClose}
-            aria-label="닫기"
-          >
-            <XIcon className="h-5 w-5" />
-          </Button>
-        </div>
-        <div className="max-h-72 overflow-y-auto px-4 py-3">
-          <ProductList products={products} />
-        </div>
-      </div>
-
+      <StorePanel
+        storeName={storeName}
+        products={products}
+        onClose={onClose}
+        containerClass="absolute inset-x-0 bottom-0 z-30 rounded-t-2xl bg-white shadow-2xl md:hidden"
+        contentClass="max-h-72 overflow-y-auto px-4 py-3"
+      />
       {/* 데스크탑: 우측 사이드바 */}
-      <div className="absolute inset-y-0 right-0 z-30 hidden w-80 flex-col bg-white shadow-2xl md:flex">
-        <div className="flex items-center justify-between border-b border-gray-100 px-4 py-4">
-          <h2 className="text-base font-semibold text-gray-900">
-            {storeName ?? '가게 정보'}
-          </h2>
-          <Button
-            type="button"
-            variant="ghost"
-            color="gray"
-            className="p-1"
-            onClick={onClose}
-            aria-label="닫기"
-          >
-            <XIcon className="h-5 w-5" />
-          </Button>
-        </div>
-        <div className="flex-1 overflow-y-auto px-4 py-3">
-          <ProductList products={products} />
-        </div>
-      </div>
+      <StorePanel
+        storeName={storeName}
+        products={products}
+        onClose={onClose}
+        containerClass="absolute inset-y-0 right-0 z-30 hidden w-80 flex-col bg-white shadow-2xl md:flex"
+        contentClass="flex-1 overflow-y-auto px-4 py-3"
+      />
     </>
   );
 }

--- a/src/hooks/products/useProducts.ts
+++ b/src/hooks/products/useProducts.ts
@@ -1,7 +1,7 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
 import type { UseQueryResult } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { useState } from 'react';
 
 import type { PaginatedResult } from '@/types/common';
@@ -13,7 +13,9 @@ import { productApi } from '@/api/products/productApi';
 interface UseProductsOptions {
   enabled?: boolean;
   initialData?: PaginatedResult<Product>;
+  keepPrevious?: boolean;
 }
+
 const INITIAL_PRODUCT_LIST_STALE_TIME_MS = 30_000;
 
 export function useProducts(
@@ -33,5 +35,6 @@ export function useProducts(
     initialDataUpdatedAt,
     refetchOnMount: hasInitialData ? false : undefined,
     staleTime: hasInitialData ? INITIAL_PRODUCT_LIST_STALE_TIME_MS : 0,
+    placeholderData: options?.keepPrevious ? keepPreviousData : undefined,
   });
 }

--- a/src/lib/kakao/map.ts
+++ b/src/lib/kakao/map.ts
@@ -18,15 +18,25 @@ interface KakaoMapsEvent {
   removeListener(target: object, event: string, handler: () => void): void;
 }
 
+interface KakaoMarkerClustererInstance {
+  addMarkers(markers: KakaoMarkerInstance[]): void;
+  clear(): void;
+}
+
 interface KakaoMapsConstructors {
   Map: new (container: HTMLElement, options: object) => KakaoMapInstance;
   LatLng: new (lat: number, lng: number) => KakaoLatLng;
   Marker: new (options: object) => KakaoMarkerInstance;
+  MarkerClusterer: new (options: object) => KakaoMarkerClustererInstance;
   event: KakaoMapsEvent;
   load(callback: () => void): void;
 }
 
-export type { KakaoMapInstance, KakaoMarkerInstance };
+export type {
+  KakaoMapInstance,
+  KakaoMarkerInstance,
+  KakaoMarkerClustererInstance,
+};
 export { loadKakaoMapsSDK } from './sdk';
 
 export function getKakaoMaps(): KakaoMapsConstructors {
@@ -62,4 +72,15 @@ export function createKakaoMarker(
   const maps = getKakaoMaps();
   const position = new maps.LatLng(lat, lng);
   return new maps.Marker({ position, map });
+}
+
+export function createMarkerClusterer(
+  map: KakaoMapInstance
+): KakaoMarkerClustererInstance {
+  const maps = getKakaoMaps();
+  return new maps.MarkerClusterer({
+    map,
+    averageCenter: true,
+    minLevel: 6,
+  });
 }

--- a/src/lib/kakao/map.ts
+++ b/src/lib/kakao/map.ts
@@ -65,13 +65,12 @@ export function initKakaoMap(
 }
 
 export function createKakaoMarker(
-  map: KakaoMapInstance,
   lat: number,
   lng: number
 ): KakaoMarkerInstance {
   const maps = getKakaoMaps();
   const position = new maps.LatLng(lat, lng);
-  return new maps.Marker({ position, map });
+  return new maps.Marker({ position });
 }
 
 export function createMarkerClusterer(

--- a/src/lib/kakao/sdk.ts
+++ b/src/lib/kakao/sdk.ts
@@ -34,7 +34,7 @@ export function loadKakaoMapsSDK(): Promise<void> {
     );
   }
   sdkLoadingPromise = loadScript(
-    `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${appKey}&libraries=services&autoload=false`
+    `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${appKey}&libraries=services,clusterer&autoload=false`
   )
     .then(
       () =>


### PR DESCRIPTION
## 📌 작업 내용

- T21에서 구현한 `/map` 페이지의 UI/UX를 개선한다
- 반응형 레이아웃, 지도 인터랙션, 핀 클러스터링, 상품 상세 진입 흐름을 포함한다

Task ID: T68

## 🔧 변경 사항

- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [x] 문서 수정

## 📚 문서/Task 반영

- [x] 관련 `docs/*` 최신화 필요 여부 확인
- [x] 필요한 문서 수정 반영 또는 후속 task/확인 필요로 기록
- [x] `docs/tasks` 상태와 GitHub Issue 번호 갱신

## 📂 주요 변경 파일

- src/lib/kakao/map.ts
- src/lib/kakao/sdk.ts
- src/components/consumer/StoreMapView.tsx
- src/components/consumer/MapPageClient.tsx
- src/components/consumer/StoreProductBottomSheet.tsx
- src/components/consumer/MapViewFab.tsx
- src/hooks/products/useProducts.ts
- docs/tasks/T68_map_ui_ux_improvement.md

## 🧪 테스트 방법

- `/map` 접속 후 위치 설정
- 핀 클릭 → 데스크탑: 우측 사이드바 / 모바일: 하단 시트 표시 확인
- 지도 드래그/줌 이동 → 핀 목록 갱신 확인
- 줌 아웃 → 밀집 핀 클러스터링 확인 / 줌 인 → 개별 핀 분리 확인
- 사이드바/하단 시트 상품 클릭 → 상품 상세 페이지 이동 확인
- 지도 이동 중 사이드바 깜빡임 없는지 확인

## 📸 스크린샷 (선택)

## 🔗 관련 이슈

- ex) close #266 
