### PR TITLE
fix: 내 예약 상품 이미지 표시 수정

### DIFF
--- a/e2e/consumer-order.spec.ts
+++ b/e2e/consumer-order.spec.ts
@@ -17,7 +17,9 @@ test('상품 상세 → 주문 → 결제 팝업 → 완료', async ({ consumerP
   await targetSlot.click();
 
   // 담기 버튼 클릭 → 주문 페이지 진입
-  await page.getByRole('button', { name: /원 담기/ }).click();
+  const cartButton = page.getByRole('button', { name: /원 담기/ });
+  await expect(cartButton).toBeEnabled({ timeout: 15_000 });
+  await cartButton.click();
   await expect(page).toHaveURL(/\/order\//, { timeout: 10_000 });
 
   // 주문 페이지에서 결제 팝업 흐름

--- a/e2e/consumer-order.spec.ts
+++ b/e2e/consumer-order.spec.ts
@@ -17,9 +17,7 @@ test('상품 상세 → 주문 → 결제 팝업 → 완료', async ({ consumerP
   await targetSlot.click();
 
   // 담기 버튼 클릭 → 주문 페이지 진입
-  const cartButton = page.getByRole('button', { name: /원 담기/ });
-  await expect(cartButton).toBeEnabled({ timeout: 15_000 });
-  await cartButton.click();
+  await page.getByRole('button', { name: /원 담기/ }).click();
   await expect(page).toHaveURL(/\/order\//, { timeout: 10_000 });
 
   // 주문 페이지에서 결제 팝업 흐름

--- a/src/app/api/orders/_lib/service.test.ts
+++ b/src/app/api/orders/_lib/service.test.ts
@@ -342,7 +342,7 @@ function makeListClient({
   const client = {
     from: vi.fn().mockReturnValue({ select: selectFn }),
   };
-  return { client, userEqFn, statusEqFn, orderFn, rangeFn };
+  return { client, selectFn, userEqFn, statusEqFn, orderFn, rangeFn };
 }
 
 function makeDetailClient({
@@ -379,6 +379,20 @@ describe('getOrders', () => {
     expect(result.pageSize).toBe(20);
     expect(result.totalCount).toBe(1);
     expect(result.totalPages).toBe(1);
+  });
+
+  it('주문 목록 조회 시 상품 이미지 조인을 포함한다', async () => {
+    const { client, selectFn } = makeListClient();
+    vi.mocked(createServiceRoleClient).mockReturnValue(
+      client as unknown as ReturnType<typeof createServiceRoleClient>
+    );
+
+    await getOrders('user-1', defaultParams);
+
+    expect(selectFn).toHaveBeenCalledWith(
+      expect.stringContaining('order_items(products(menu_items(image)))'),
+      { count: 'exact' }
+    );
   });
 
   it('status 필터 있음: eq("status", ...) 호출', async () => {

--- a/src/app/api/orders/_lib/service.ts
+++ b/src/app/api/orders/_lib/service.ts
@@ -181,7 +181,7 @@ export async function getOrders(
   let query = supabase
     .from('orders')
     .select(
-      'id, order_number, store_id, total_amount, discount_amount, payment_amount, status, pickup_at, pickup_service_date, store_order_number, pickup_number, expires_at, created_at, updated_at, stores(name)',
+      'id, order_number, store_id, total_amount, discount_amount, payment_amount, status, pickup_at, pickup_service_date, store_order_number, pickup_number, expires_at, created_at, updated_at, stores(name), order_items(products(menu_items(image)))',
       { count: 'exact' }
     )
     .eq('user_id', userId);

--- a/src/components/consumer/mypage/mypageReservationMapper.test.ts
+++ b/src/components/consumer/mypage/mypageReservationMapper.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Order } from '@/types/order';
+
+import { mapOrderToMypageReservation } from './mypageReservationMapper';
+
+const baseOrder: Omit<Order, 'items' | 'payment'> = {
+  id: 'order-1',
+  orderNumber: 'PM202606230001',
+  storeId: 'store-1',
+  storeName: '픽마 베이커리',
+  totalAmount: 12000,
+  discountAmount: 4000,
+  paymentAmount: 8000,
+  status: 'reserved',
+  pickupAt: new Date('2026-06-23T09:00:00.000Z'),
+  pickupServiceDate: new Date('2026-06-23T00:00:00.000Z'),
+  storeOrderNumber: 'A-001',
+  pickupNumber: 'P001',
+  createdAt: new Date('2026-06-23T08:00:00.000Z'),
+  updatedAt: new Date('2026-06-23T08:00:00.000Z'),
+};
+
+describe('mapOrderToMypageReservation', () => {
+  it('주문 목록 이미지가 있으면 예약 카드 이미지로 사용한다', () => {
+    const reservation = mapOrderToMypageReservation({
+      ...baseOrder,
+      image: '/images/mock/products/product-salad.jpg',
+    });
+
+    expect(reservation.imageUrl).toBe(
+      '/images/mock/products/product-salad.jpg'
+    );
+  });
+
+  it('주문 목록 이미지가 없으면 fallback 이미지를 사용한다', () => {
+    const reservation = mapOrderToMypageReservation(baseOrder);
+
+    expect(reservation.imageUrl).toBe('/images/fallback/bread.jpg');
+  });
+});

--- a/src/components/consumer/mypage/mypageReservationMapper.ts
+++ b/src/components/consumer/mypage/mypageReservationMapper.ts
@@ -51,7 +51,7 @@ export function mapOrderToMypageReservation(
     orderNumber: order.storeOrderNumber ?? order.orderNumber,
     storeName: order.storeName,
     productName: null,
-    imageUrl: FALLBACK_RESERVATION_IMAGE_URL,
+    imageUrl: order.image ?? FALLBACK_RESERVATION_IMAGE_URL,
     pickupDate: formatPickupDate(order.pickupAt),
     pickupTime: formatPickupTime(order.pickupAt),
     pickupCode: order.pickupNumber ?? null,


### PR DESCRIPTION
## 📌 작업 내용

- 내 예약 화면에서 모든 상품 이미지가 기본 빵 이미지로 표시되던 문제를 수정했습니다.
- 주문 목록 API 응답에 상품 이미지 정보가 포함되도록 이미지 조인을 추가했습니다.
- 마이페이지 예약 mapper에서 실제 상품 이미지가 있으면 우선 사용하고, 없을 때만 fallback 이미지를 사용하도록 변경했습니다.
- 상품 이미지 매핑 동작을 검증하는 테스트를 추가했습니다.
